### PR TITLE
Use payout when determining main result type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.109",
+  "version": "1.0.110",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bet-calculator.class.ts
+++ b/src/BetCalculator/bet-calculator.class.ts
@@ -856,13 +856,15 @@ export class BetCalculator {
       bog_amount_won,
     });
 
-    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles]);
+    const total_payout = doubles_payout + trebles_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles], total_payout);
 
     return {
       singles: [],
       combinations: [...doubles.combinations, ...trebles.combinations],
       stake: doubles_stake + trebles_stake,
-      payout: doubles_payout + trebles_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -901,13 +903,15 @@ export class BetCalculator {
 
     this.profit = win_profit + place_profit;
 
-    const main_result_type = this.calculatorHelper.getMainResultType([...singles, doubles, trebles]);
+    const total_payout = singles_payout + doubles_payout + trebles_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([...singles, doubles, trebles], total_payout);
 
     return {
       singles: singles.map((single) => single.singles).flat(),
       combinations: [...doubles.combinations, ...trebles.combinations],
       stake: singles_stake + doubles_stake + trebles_stake,
-      payout: singles_payout + doubles_payout + trebles_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -936,13 +940,15 @@ export class BetCalculator {
 
     const bog_amount_won = doubles.bog_amount_won + trebles.bog_amount_won + accumulator.bog_amount_won;
 
-    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles]);
+    const total_payout = doubles_payout + trebles_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator], total_payout);
 
     return {
       singles: singles.map((single) => single.singles).flat(),
       combinations: [...doubles.combinations, ...trebles.combinations],
       stake: doubles_stake + trebles_stake + accumulator.stake,
-      payout: doubles_payout + trebles_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -976,13 +982,10 @@ export class BetCalculator {
     const win_profit = doubles.win_profit + trebles.win_profit + folds.win_profit + accumulator.win_profit;
     const place_profit = doubles.place_profit + trebles.place_profit + folds.place_profit + accumulator.place_profit;
 
-    const main_result_type = this.calculatorHelper.getMainResultType([
-      ...singles,
-      doubles,
-      trebles,
-      folds,
-      accumulator,
-    ]);
+    const main_result_type = this.calculatorHelper.getMainResultType(
+      [...singles, doubles, trebles, folds, accumulator],
+      total_payout,
+    );
 
     return {
       singles: singles.map((single) => single.singles).flat(),
@@ -1034,7 +1037,9 @@ export class BetCalculator {
 
     console.log('Heinz', JSON.stringify({ selections, singles, doubles, trebles, fourfolds, fivefolds, accumulator }));
 
-    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator]);
+    const total_payout = doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator], total_payout);
 
     return {
       singles: singles.map((single) => single.singles).flat(),
@@ -1045,7 +1050,7 @@ export class BetCalculator {
         ...fivefolds.combinations,
       ],
       stake: doubles_stake + trebles_stake + fourfolds_stake + fivefolds_stake + accumulator.stake,
-      payout: doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1076,7 +1081,11 @@ export class BetCalculator {
     const sixfolds_payout = sixfolds.payout;
     const sixfolds_stake = sixfolds.stake;
     const accumulator_payout = accumulator.payout;
-    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator]);
+
+    const total_payout =
+      doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + sixfolds_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator], total_payout);
 
     const win_profit =
       doubles.win_profit +
@@ -1110,8 +1119,7 @@ export class BetCalculator {
         ...sixfolds.combinations,
       ],
       stake: doubles_stake + trebles_stake + fourfolds_stake + fivefolds_stake + sixfolds_stake + accumulator.stake,
-      payout:
-        doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + sixfolds_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1145,7 +1153,17 @@ export class BetCalculator {
     const sevenfolds_payout = sevenfolds.payout;
     const sevenfolds_stake = sevenfolds.stake;
     const accumulator_payout = accumulator.payout;
-    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator]);
+
+    const total_payout =
+      doubles_payout +
+      trebles_payout +
+      fourfolds_payout +
+      fivefolds_payout +
+      sixfolds_payout +
+      sevenfolds_payout +
+      accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType([doubles, trebles, accumulator], total_payout);
 
     const win_profit =
       doubles.win_profit +
@@ -1190,14 +1208,7 @@ export class BetCalculator {
         sixfolds_stake +
         sevenfolds_stake +
         accumulator.stake,
-      payout:
-        doubles_payout +
-        trebles_payout +
-        fourfolds_payout +
-        fivefolds_payout +
-        sixfolds_payout +
-        sevenfolds_payout +
-        accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1223,7 +1234,13 @@ export class BetCalculator {
     const trebles_payout = trebles.payout;
     const trebles_stake = trebles.stake;
     const accumulator_payout = accumulator.payout;
-    const main_result_type = this.calculatorHelper.getMainResultType([...singles, doubles, trebles, accumulator]);
+
+    const total_payout = singles_payout + doubles_payout + trebles_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType(
+      [...singles, doubles, trebles, accumulator],
+      total_payout,
+    );
 
     const win_profit = singles_win_profit + doubles.win_profit + trebles.win_profit + accumulator.win_profit;
     const place_profit = singles_place_profit + doubles.place_profit + trebles.place_profit + accumulator.place_profit;
@@ -1237,7 +1254,7 @@ export class BetCalculator {
       singles: singles.map((single) => single.singles).flat(),
       combinations: [...doubles.combinations, ...trebles.combinations],
       stake: singles_stake + doubles_stake + trebles_stake + accumulator.stake,
-      payout: singles_payout + doubles_payout + trebles_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1266,7 +1283,13 @@ export class BetCalculator {
     const fourfolds_payout = fourfolds.payout;
     const fourfolds_stake = fourfolds.stake;
     const accumulator_payout = accumulator.payout;
-    const main_result_type = this.calculatorHelper.getMainResultType([...singles, doubles, trebles, accumulator]);
+
+    const total_payout = singles_payout + doubles_payout + trebles_payout + fourfolds_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType(
+      [...singles, doubles, trebles, accumulator],
+      total_payout,
+    );
 
     const win_profit =
       singles_win_profit + doubles.win_profit + trebles.win_profit + fourfolds.win_profit + accumulator.win_profit;
@@ -1295,7 +1318,7 @@ export class BetCalculator {
       singles: singles.map((single) => single.singles).flat(),
       combinations: [...doubles.combinations, ...trebles.combinations, ...fourfolds.combinations],
       stake: singles_stake + doubles_stake + trebles_stake + fourfolds_stake + accumulator.stake,
-      payout: singles_payout + doubles_payout + trebles_payout + fourfolds_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1327,7 +1350,14 @@ export class BetCalculator {
     const fivefolds_payout = fivefolds.payout;
     const fivefolds_stake = fivefolds.stake;
     const accumulator_payout = accumulator.payout;
-    const main_result_type = this.calculatorHelper.getMainResultType([...singles, doubles, trebles, accumulator]);
+
+    const total_payout =
+      singles_payout + doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + accumulator_payout;
+
+    const main_result_type = this.calculatorHelper.getMainResultType(
+      [...singles, doubles, trebles, accumulator],
+      total_payout,
+    );
 
     const win_profit =
       singles_win_profit +
@@ -1360,8 +1390,7 @@ export class BetCalculator {
         ...fivefolds.combinations,
       ],
       stake: singles_stake + doubles_stake + trebles_stake + fourfolds_stake + fivefolds_stake + accumulator.stake,
-      payout:
-        singles_payout + doubles_payout + trebles_payout + fourfolds_payout + fivefolds_payout + accumulator_payout,
+      payout: total_payout,
       result_type: main_result_type,
       win_profit,
       place_profit,
@@ -1491,7 +1520,7 @@ export class BetCalculator {
     foldCombinations.forEach((combination) => {
       const result: ResultMainBet = this.processAccumulatorBet(combination);
 
-      const combination_result_type = this.calculatorHelper.getMainResultType([result]);
+      const combination_result_type = this.calculatorHelper.getMainResultType([result], result.payout);
 
       results.push({
         payout: result.payout,

--- a/src/BetCalculator/bet-calculator.helper.ts
+++ b/src/BetCalculator/bet-calculator.helper.ts
@@ -458,7 +458,7 @@ export class BetCalculatorHelper {
     return BetResultType.LOSER;
   };
 
-  getMainResultType = (combinations: ResultMainBet[]): BetResultType => {
+  getMainResultType = (combinations: ResultMainBet[], payout: number): BetResultType => {
     const result_type = BetResultType.OPEN;
 
     if (combinations.length === 0) {
@@ -478,15 +478,15 @@ export class BetCalculatorHelper {
     );
     const has_void = combinations.some((combination) => combination.result_type === BetResultType.VOID);
 
-    if (has_winner) {
+    if (has_winner && payout > 0) {
       return BetResultType.WINNER;
     }
 
-    if (has_partial) {
+    if (has_partial && payout > 0) {
       return BetResultType.PARTIAL;
     }
 
-    if (has_void) {
+    if (has_void && payout > 0) {
       return BetResultType.PARTIAL;
     }
 

--- a/src/tests/BetCalculator/canadians.test.ts
+++ b/src/tests/BetCalculator/canadians.test.ts
@@ -440,6 +440,105 @@ describe('Canadian Simple Winner Case', () => {
     expect(result.result_type).toBe(BetResultType.PARTIAL);
   });
 
+  it('Canadian 4 Losers 1 Placed', () => {
+    const bets = [
+      {
+        bet_id: 1,
+        bet_type: BetSlipType.SINGLE,
+        stake: 0.3,
+        result: BetResultType.LOSER,
+        is_starting_price: false,
+        sp_odd_fractional: '',
+        odd_fractional: '1/4',
+        ew_terms: '',
+        partial_win_percent: 0,
+        rule_4: 0,
+        is_each_way: false,
+        sp_odd_decimal: 0,
+        odd_decimal: 0,
+      },
+      {
+        bet_id: 2,
+        bet_type: BetSlipType.SINGLE,
+        stake: 0.3,
+        result: BetResultType.LOSER,
+        is_starting_price: false,
+        sp_odd_fractional: '',
+        odd_fractional: '1/2',
+        ew_terms: '',
+        partial_win_percent: 0,
+        rule_4: 0,
+        is_each_way: false,
+        sp_odd_decimal: 0,
+        odd_decimal: 0,
+      },
+      {
+        bet_id: 3,
+        bet_type: BetSlipType.SINGLE,
+        stake: 0.3,
+        result: BetResultType.PLACED,
+        is_starting_price: false,
+        sp_odd_fractional: null,
+        odd_fractional: '1/3',
+        ew_terms: '',
+        partial_win_percent: 0,
+        rule_4: 0,
+        is_each_way: false,
+        sp_odd_decimal: 0,
+        odd_decimal: 0,
+      },
+      {
+        bet_id: 4,
+        bet_type: BetSlipType.SINGLE,
+        stake: 0.3,
+        result: BetResultType.LOSER,
+        is_starting_price: false,
+        sp_odd_fractional: null,
+        odd_fractional: '',
+        ew_terms: '',
+        partial_win_percent: 0,
+        rule_4: 0,
+        is_each_way: false,
+        sp_odd_decimal: 0,
+        odd_decimal: 9,
+      },
+      {
+        bet_id: 5,
+        bet_type: BetSlipType.SINGLE,
+        stake: 0.3,
+        result: BetResultType.LOSER,
+        is_starting_price: false,
+        sp_odd_fractional: null,
+        odd_fractional: '',
+        ew_terms: '',
+        partial_win_percent: 0,
+        rule_4: 0,
+        is_each_way: false,
+        sp_odd_decimal: 0,
+        odd_decimal: 4.2,
+      },
+    ];
+    const selections = [];
+
+    const result = betCalculator.processBet({
+      stake: 0.3,
+      total_stake: 0.3,
+      bets,
+      selections,
+      bet_type: BetSlipType.CANADIAN,
+      free_bet_amount: 0,
+      bog_applicable: false,
+      bog_max_payout: 0,
+      max_payout: 0,
+      each_way: true,
+    });
+
+    console.log('Canadian', JSON.stringify(result));
+
+    expect(result.return_payout).toBeCloseTo(0.0, 1);
+    expect(result.result_type).toBe(BetResultType.LOSER);
+  });
+
   it('CANADIAN: BOG with SP odds higher than main odds (WINNER×5) → expect result_type WINNER with BOG benefit', () => {
     const bets = [
       {


### PR DESCRIPTION
Compute and reuse total_payout across BetCalculator branches and pass it into getMainResultType; replace repeated inline payout sums with total_payout for returned payout values. Update BetCalculatorHelper.getMainResultType signature to accept a payout argument and only treat combinations as WINNER/PARTIAL/VOID if payout > 0 (preventing false PARTIAL when payout is zero). Add a new Canadian test case ("Canadian 4 Losers 1 Placed") to cover a zero-return scenario.