### PR TITLE
feat(1.0.117): add Bet Builder settlement to BetCalculator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.116",
+  "version": "1.0.117",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.116",
+      "version": "1.0.117",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.116",
+  "version": "1.0.117",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bet-calculator.class.ts
+++ b/src/BetCalculator/bet-calculator.class.ts
@@ -45,6 +45,8 @@ export class BetCalculator {
 
   fold_type: number = 0;
 
+  decimal: number = 0;
+
   calculatorHelper: BetCalculatorHelper = new BetCalculatorHelper();
 
   reset = () => {
@@ -63,6 +65,7 @@ export class BetCalculator {
     this.free_bet_amount = 0;
     this.payout = 0;
     this.each_way = false;
+    this.decimal = 0;
   };
 
   private sanitizeNumber = (value: unknown, fallback: number = 0): number => {
@@ -164,6 +167,7 @@ export class BetCalculator {
       bog_applicable,
       each_way,
       fold_type,
+      decimal,
     } = betSettings;
     this.stake = +stake;
     this.total_stake = +total_stake;
@@ -176,6 +180,7 @@ export class BetCalculator {
     this.bog_applicable = bog_applicable || false;
     this.each_way = each_way || false;
     this.fold_type = fold_type || 0;
+    this.decimal = +(decimal || 0);
 
     this.validateBetsAndSettings();
 
@@ -220,6 +225,8 @@ export class BetCalculator {
       result = this.processLucky63Bet(this.bets);
     } else if (this.bet_type.includes(BetSlipType.FOLD)) {
       result = this.processFoldBet(this.bets, this.fold_type);
+    } else if (this.bet_type === BetSlipType.BET_BUILDER) {
+      result = this.processBetBuilderBet(this.bets, this.decimal);
     }
     // else if (this.bet_type === BetSlipType.SUPER_GOLIATH) {
     // result = this.processSuperGoliathBet(this.bets);
@@ -1698,5 +1705,108 @@ export class BetCalculator {
 
     generateCombinations(selections, combinationSize);
     return result;
+  };
+
+  /**
+   * Settle a Bet Builder bet.
+   *
+   * Rules:
+   *   - any losing leg              → bet loses (payout = 0)
+   *   - all winners, no voids       → payout = decimal × stake (the original BB combined price)
+   *   - mix of winners + voids      → payout = (∏ surviving leg odds) × stake (acca of survivors)
+   *   - all legs void               → refund stake
+   *
+   * Half-result legs use the same effective-odd as accumulator settlement:
+   *   half_won → odd_decimal / 2     half_lost → 0.5
+   *
+   * BB has no Rule 4 and no BOG. Boosts (BB_BOOST only) are applied by callers
+   * outside this function.
+   */
+  processBetBuilderBet = (selections: PlacedBetSelection[], decimal: number): ResultMainBet => {
+    const stake = this.stake;
+    let no_of_winners = 0;
+    let no_of_voids = 0;
+    let no_of_losers = 0;
+    const surviving_odds: number[] = [];
+
+    for (const leg of selections) {
+      const result = leg.result;
+      const odd = +(leg.odd_decimal ?? 0);
+
+      if (result === BetResultType.WINNER) {
+        no_of_winners++;
+        surviving_odds.push(odd);
+      } else if (result === BetResultType.VOID) {
+        no_of_voids++;
+      } else if (result === BetResultType.HALF_WON) {
+        no_of_winners++;
+        surviving_odds.push(odd / 2);
+      } else if (result === BetResultType.HALF_LOST) {
+        no_of_winners++;
+        surviving_odds.push(0.5);
+      } else if (result === BetResultType.LOSER) {
+        no_of_losers++;
+      }
+    }
+
+    // Any loser → bet loses
+    if (no_of_losers > 0) {
+      return {
+        stake: 0,
+        payout: 0,
+        result_type: BetResultType.LOSER,
+        win_profit: 0,
+        place_profit: 0,
+        singles: [],
+        combinations: [],
+        accumulator_profit: 0,
+        profit: 0,
+        bog_amount_won: 0,
+      };
+    }
+
+    // All voids → refund stake
+    if (no_of_voids === selections.length && selections.length > 0) {
+      return {
+        stake,
+        payout: stake,
+        result_type: BetResultType.VOID,
+        win_profit: 0,
+        place_profit: 0,
+        singles: [],
+        combinations: [],
+        accumulator_profit: 0,
+        profit: 0,
+        bog_amount_won: 0,
+      };
+    }
+
+    // All winners (no voids) → use the pricing-engine combined price
+    let new_odds: number;
+    if (no_of_voids === 0 && no_of_winners === selections.length) {
+      if (!(decimal > 0)) {
+        throw new Error(`Bet Builder decimal must be > 0 (got ${decimal})`);
+      }
+      new_odds = decimal;
+    } else {
+      // Mix of winners + voids → recompute as acca of surviving legs
+      new_odds = surviving_odds.reduce((acc, o) => acc * o, 1);
+    }
+
+    const payout = new_odds * stake;
+    const win_profit = payout - stake;
+
+    return {
+      stake,
+      payout,
+      result_type: BetResultType.WINNER,
+      win_profit,
+      place_profit: 0,
+      singles: [],
+      combinations: [],
+      accumulator_profit: 0,
+      profit: win_profit,
+      bog_amount_won: 0,
+    };
   };
 }

--- a/src/common/constants/betSlipType.ts
+++ b/src/common/constants/betSlipType.ts
@@ -21,6 +21,7 @@ export enum BetSlipType {
   TRIFECTA = 'bet_slip_place_trifecta',
   SWINGER = 'bet_slip_place_swinger',
   FOLD = 'bet_slip_place_fold',
+  BET_BUILDER = 'bet_builder',
 }
 
 export const BetSlipTypeName: Record<BetSlipType, string> = {
@@ -46,6 +47,7 @@ export const BetSlipTypeName: Record<BetSlipType, string> = {
   [BetSlipType.TRIFECTA]: 'Trifecta',
   [BetSlipType.SWINGER]: 'Swinge',
   [BetSlipType.FOLD]: 'Fold',
+  [BetSlipType.BET_BUILDER]: 'Bet Builder',
 };
 
 export enum CastType {

--- a/src/common/dto/PlacedBet.ts
+++ b/src/common/dto/PlacedBet.ts
@@ -47,6 +47,7 @@ export interface BetSettings {
   free_bet_amount: number;
   bog_applicable: boolean;
   each_way: boolean;
+  decimal?: number;
 }
 
 export interface ResultSingle {

--- a/src/tests/BetCalculator/betBuilder.test.ts
+++ b/src/tests/BetCalculator/betBuilder.test.ts
@@ -1,0 +1,189 @@
+import { BetCalculator } from '../../BetCalculator/bet-calculator.class';
+import { BetSlipType } from '../../common/constants/betSlipType';
+import { BetResultType } from '../../common/constants/betResultType';
+import type { PlacedBetSelection } from '../../common/dto/PlacedBet';
+
+const leg = (result: BetResultType, odd_decimal: number, bet_id = 1): PlacedBetSelection => ({
+  bet_id,
+  stake: 0,
+  result,
+  is_starting_price: false,
+  sp_odd_fractional: '',
+  odd_fractional: '',
+  ew_terms: '',
+  partial_win_percent: 0,
+  rule_4: 0,
+  is_each_way: false,
+  sp_odd_decimal: 0,
+  odd_decimal,
+});
+
+const settle = (calculator: BetCalculator, args: { stake: number; decimal: number; bets: PlacedBetSelection[] }) =>
+  calculator.processBet({
+    stake: args.stake,
+    total_stake: args.stake,
+    bets: args.bets,
+    bet_type: BetSlipType.BET_BUILDER,
+    free_bet_amount: 0,
+    bog_applicable: false,
+    bog_max_payout: 0,
+    max_payout: 0,
+    each_way: false,
+    decimal: args.decimal,
+  });
+
+describe('Bet Builder — settlement (spec coverage)', () => {
+  const calc = new BetCalculator();
+
+  it('Ex 1: 2 legs, 1 void → settles as single at survivor (1.50) → $15 on $10', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 2.5,
+      bets: [leg(BetResultType.VOID, 2.0, 1), leg(BetResultType.WINNER, 1.5, 2)],
+    });
+    expect(r.return_payout).toBeCloseTo(15, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('Ex 2: 3 legs, 1 void → acca of survivors (1.50 × 1.80) × 10 = $27', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.VOID, 2.0, 1),
+        leg(BetResultType.WINNER, 1.5, 2),
+        leg(BetResultType.WINNER, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(27, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('Ex 3: 3 legs, 2 voids → single survivor at 1.80 → $18', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.VOID, 2.0, 1),
+        leg(BetResultType.VOID, 1.5, 2),
+        leg(BetResultType.WINNER, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(18, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('Ex 5: 4 legs, 2 voids middle → (1.50 × 2.50) × 10 = $37.50', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 13.5,
+      bets: [
+        leg(BetResultType.WINNER, 1.5, 1),
+        leg(BetResultType.VOID, 1.8, 2),
+        leg(BetResultType.VOID, 2.0, 3),
+        leg(BetResultType.WINNER, 2.5, 4),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(37.5, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('Ex 7: 6 legs, 5 voids → single survivor at 1.75 → $17.50', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 33.08,
+      bets: [
+        leg(BetResultType.VOID, 2.0, 1),
+        leg(BetResultType.VOID, 1.5, 2),
+        leg(BetResultType.VOID, 1.8, 3),
+        leg(BetResultType.VOID, 2.5, 4),
+        leg(BetResultType.VOID, 1.4, 5),
+        leg(BetResultType.WINNER, 1.75, 6),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(17.5, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('All winners → uses decimal (combined BB price) × stake (unchanged behaviour)', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.WINNER, 2.0, 1),
+        leg(BetResultType.WINNER, 1.5, 2),
+        leg(BetResultType.WINNER, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(54, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('Any losing leg → bet loses (payout = 0)', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.WINNER, 2.0, 1),
+        leg(BetResultType.LOSER, 1.5, 2),
+        leg(BetResultType.VOID, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(0, 5);
+    expect(r.result_type).toBe(BetResultType.LOSER);
+  });
+
+  it('All voids → refund stake', () => {
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.VOID, 2.0, 1),
+        leg(BetResultType.VOID, 1.5, 2),
+        leg(BetResultType.VOID, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(10, 5);
+    expect(r.result_type).toBe(BetResultType.VOID);
+  });
+
+  it('All winners but decimal = 0 → throws', () => {
+    expect(() =>
+      settle(calc, {
+        stake: 10,
+        decimal: 0,
+        bets: [leg(BetResultType.WINNER, 2.0, 1), leg(BetResultType.WINNER, 1.5, 2)],
+      }),
+    ).toThrow(/decimal must be > 0/);
+  });
+
+  it('half_won uses odd/2 as effective survivor odd', () => {
+    // half_won 2.0 → 1.0; × winner 1.5 → 1.5 × $10 = $15
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.HALF_WON, 2.0, 1),
+        leg(BetResultType.WINNER, 1.5, 2),
+        leg(BetResultType.VOID, 1.8, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(15, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('half_lost uses 0.5 as effective survivor odd', () => {
+    // half_lost → 0.5; × winner 1.8 → 0.9 × $10 = $9
+    const r = settle(calc, {
+      stake: 10,
+      decimal: 5.4,
+      bets: [
+        leg(BetResultType.HALF_LOST, 2.0, 1),
+        leg(BetResultType.WINNER, 1.8, 2),
+        leg(BetResultType.VOID, 1.5, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(9, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `BetSlipType.BET_BUILDER` enum value and `BetSettings.decimal` optional field
- Adds `BetCalculator.processBetBuilderBet` method, dispatched from `processBet` when `bet_type === BET_BUILDER`
- 11 unit tests covering the spec's worked examples (`src/tests/BetCalculator/betBuilder.test.ts`)
- Bumps version to 1.0.117

## Settlement rules
- any losing leg → bet loses (payout 0)
- all winners, no voids → payout = `decimal × stake` (the original BB combined price set by the pricing engine)
- mix of winners + voids → payout = `(∏ surviving leg odds) × stake` (acca of survivors)
- all legs void → refund stake
- half_won → effective odd = odd_decimal / 2; half_lost → 0.5 (parity with accumulator settlement)

## Why
Bet Builder bets currently have no settlement branch in the shared `BetCalculator` and no void-leg recalculation in the cron settlement path. ELBAPI's cron has a placeholder that leaves BB bets open whenever a leg voids. This PR is the foundation for the cron and CMS manual-settle paths to share one BB settlement implementation.

## Test plan
- [x] `npx jest src/tests/BetCalculator/betBuilder.test.ts` — 11/11 pass
- [x] `npx jest src/tests/BetCalculator` — 141/141 pass (no regression)
- [x] `npx tsc` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)