### PR TITLE
chore(1.0.118): version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.117",
+  "version": "1.0.118",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.117",
+      "version": "1.0.118",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.117",
+  "version": "1.0.118",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Re-release of the Bet Builder settlement additions (originally in `1.0.117`, PR #150) under a new version number `1.0.118` to drive a fresh consumer lockfile bump in ELBAPI and CMSEB staging.

No code changes — only `package.json` + `package-lock.json` version field bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)