### PR TITLE
feat(1.0.119): BB all-winners pays stored_payout verbatim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.118",
+  "version": "1.0.119",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.118",
+      "version": "1.0.119",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.118",
+  "version": "1.0.119",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bet-calculator.class.ts
+++ b/src/BetCalculator/bet-calculator.class.ts
@@ -45,7 +45,7 @@ export class BetCalculator {
 
   fold_type: number = 0;
 
-  decimal: number = 0;
+  stored_payout: number = 0;
 
   calculatorHelper: BetCalculatorHelper = new BetCalculatorHelper();
 
@@ -65,7 +65,7 @@ export class BetCalculator {
     this.free_bet_amount = 0;
     this.payout = 0;
     this.each_way = false;
-    this.decimal = 0;
+    this.stored_payout = 0;
   };
 
   private sanitizeNumber = (value: unknown, fallback: number = 0): number => {
@@ -167,7 +167,7 @@ export class BetCalculator {
       bog_applicable,
       each_way,
       fold_type,
-      decimal,
+      stored_payout,
     } = betSettings;
     this.stake = +stake;
     this.total_stake = +total_stake;
@@ -180,7 +180,7 @@ export class BetCalculator {
     this.bog_applicable = bog_applicable || false;
     this.each_way = each_way || false;
     this.fold_type = fold_type || 0;
-    this.decimal = +(decimal || 0);
+    this.stored_payout = +(stored_payout || 0);
 
     this.validateBetsAndSettings();
 
@@ -226,7 +226,7 @@ export class BetCalculator {
     } else if (this.bet_type.includes(BetSlipType.FOLD)) {
       result = this.processFoldBet(this.bets, this.fold_type);
     } else if (this.bet_type === BetSlipType.BET_BUILDER) {
-      result = this.processBetBuilderBet(this.bets, this.decimal);
+      result = this.processBetBuilderBet(this.bets, this.stored_payout);
     }
     // else if (this.bet_type === BetSlipType.SUPER_GOLIATH) {
     // result = this.processSuperGoliathBet(this.bets);
@@ -1712,17 +1712,23 @@ export class BetCalculator {
    *
    * Rules:
    *   - any losing leg              → bet loses (payout = 0)
-   *   - all winners, no voids       → payout = decimal × stake (the original BB combined price)
-   *   - mix of winners + voids      → payout = (∏ surviving leg odds) × stake (acca of survivors)
+   *   - all winners, no voids       → payout = stored_payout (the gross return
+   *                                   set by the pricing engine at placement,
+   *                                   stored on users_bets.return_amount). No
+   *                                   recompute — honour the price the player
+   *                                   agreed to.
+   *   - mix of winners + voids      → payout = (∏ surviving leg odds) × stake
+   *                                   (rebuild as accumulator of survivors)
    *   - all legs void               → refund stake
    *
-   * Half-result legs use the same effective-odd as accumulator settlement:
+   * Half-result legs use the same effective-odd as accumulator settlement
+   * (relevant only on the void-recalc path):
    *   half_won → odd_decimal / 2     half_lost → 0.5
    *
    * BB has no Rule 4 and no BOG. Boosts (BB_BOOST only) are applied by callers
    * outside this function.
    */
-  processBetBuilderBet = (selections: PlacedBetSelection[], decimal: number): ResultMainBet => {
+  processBetBuilderBet = (selections: PlacedBetSelection[], stored_payout: number): ResultMainBet => {
     const stake = this.stake;
     let no_of_winners = 0;
     let no_of_voids = 0;
@@ -1781,19 +1787,19 @@ export class BetCalculator {
       };
     }
 
-    // All winners (no voids) → use the pricing-engine combined price
-    let new_odds: number;
+    // All winners (no voids) → honour the stored gross return verbatim.
+    let payout: number;
     if (no_of_voids === 0 && no_of_winners === selections.length) {
-      if (!(decimal > 0)) {
-        throw new Error(`Bet Builder decimal must be > 0 (got ${decimal})`);
+      if (!(stored_payout > 0)) {
+        throw new Error(`Bet Builder stored_payout must be > 0 (got ${stored_payout})`);
       }
-      new_odds = decimal;
+      payout = stored_payout;
     } else {
-      // Mix of winners + voids → recompute as acca of surviving legs
-      new_odds = surviving_odds.reduce((acc, o) => acc * o, 1);
+      // Mix of winners + voids → recompute as acca of surviving legs.
+      const new_odds = surviving_odds.reduce((acc, o) => acc * o, 1);
+      payout = new_odds * stake;
     }
 
-    const payout = new_odds * stake;
     const win_profit = payout - stake;
 
     return {

--- a/src/common/dto/PlacedBet.ts
+++ b/src/common/dto/PlacedBet.ts
@@ -47,7 +47,7 @@ export interface BetSettings {
   free_bet_amount: number;
   bog_applicable: boolean;
   each_way: boolean;
-  decimal?: number;
+  stored_payout?: number;
 }
 
 export interface ResultSingle {

--- a/src/tests/BetCalculator/betBuilder.test.ts
+++ b/src/tests/BetCalculator/betBuilder.test.ts
@@ -18,7 +18,7 @@ const leg = (result: BetResultType, odd_decimal: number, bet_id = 1): PlacedBetS
   odd_decimal,
 });
 
-const settle = (calculator: BetCalculator, args: { stake: number; decimal: number; bets: PlacedBetSelection[] }) =>
+const settle = (calculator: BetCalculator, args: { stake: number; stored_payout: number; bets: PlacedBetSelection[] }) =>
   calculator.processBet({
     stake: args.stake,
     total_stake: args.stake,
@@ -29,7 +29,7 @@ const settle = (calculator: BetCalculator, args: { stake: number; decimal: numbe
     bog_max_payout: 0,
     max_payout: 0,
     each_way: false,
-    decimal: args.decimal,
+    stored_payout: args.stored_payout,
   });
 
 describe('Bet Builder — settlement (spec coverage)', () => {
@@ -38,7 +38,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Ex 1: 2 legs, 1 void → settles as single at survivor (1.50) → $15 on $10', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 2.5,
+      stored_payout: 25,
       bets: [leg(BetResultType.VOID, 2.0, 1), leg(BetResultType.WINNER, 1.5, 2)],
     });
     expect(r.return_payout).toBeCloseTo(15, 5);
@@ -48,7 +48,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Ex 2: 3 legs, 1 void → acca of survivors (1.50 × 1.80) × 10 = $27', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.VOID, 2.0, 1),
         leg(BetResultType.WINNER, 1.5, 2),
@@ -62,7 +62,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Ex 3: 3 legs, 2 voids → single survivor at 1.80 → $18', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.VOID, 2.0, 1),
         leg(BetResultType.VOID, 1.5, 2),
@@ -76,7 +76,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Ex 5: 4 legs, 2 voids middle → (1.50 × 2.50) × 10 = $37.50', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 13.5,
+      stored_payout: 135,
       bets: [
         leg(BetResultType.WINNER, 1.5, 1),
         leg(BetResultType.VOID, 1.8, 2),
@@ -91,7 +91,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Ex 7: 6 legs, 5 voids → single survivor at 1.75 → $17.50', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 33.08,
+      stored_payout: 330.8,
       bets: [
         leg(BetResultType.VOID, 2.0, 1),
         leg(BetResultType.VOID, 1.5, 2),
@@ -105,10 +105,10 @@ describe('Bet Builder — settlement (spec coverage)', () => {
     expect(r.result_type).toBe(BetResultType.WINNER);
   });
 
-  it('All winners → uses decimal (combined BB price) × stake (unchanged behaviour)', () => {
+  it('All winners → returns stored_payout verbatim (no recompute)', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.WINNER, 2.0, 1),
         leg(BetResultType.WINNER, 1.5, 2),
@@ -122,7 +122,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('Any losing leg → bet loses (payout = 0)', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.WINNER, 2.0, 1),
         leg(BetResultType.LOSER, 1.5, 2),
@@ -136,7 +136,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
   it('All voids → refund stake', () => {
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.VOID, 2.0, 1),
         leg(BetResultType.VOID, 1.5, 2),
@@ -147,21 +147,21 @@ describe('Bet Builder — settlement (spec coverage)', () => {
     expect(r.result_type).toBe(BetResultType.VOID);
   });
 
-  it('All winners but decimal = 0 → throws', () => {
+  it('All winners but stored_payout = 0 → throws', () => {
     expect(() =>
       settle(calc, {
         stake: 10,
-        decimal: 0,
+        stored_payout: 0,
         bets: [leg(BetResultType.WINNER, 2.0, 1), leg(BetResultType.WINNER, 1.5, 2)],
       }),
-    ).toThrow(/decimal must be > 0/);
+    ).toThrow(/stored_payout must be > 0/);
   });
 
   it('half_won uses odd/2 as effective survivor odd', () => {
     // half_won 2.0 → 1.0; × winner 1.5 → 1.5 × $10 = $15
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.HALF_WON, 2.0, 1),
         leg(BetResultType.WINNER, 1.5, 2),
@@ -176,7 +176,7 @@ describe('Bet Builder — settlement (spec coverage)', () => {
     // half_lost → 0.5; × winner 1.8 → 0.9 × $10 = $9
     const r = settle(calc, {
       stake: 10,
-      decimal: 5.4,
+      stored_payout: 54,
       bets: [
         leg(BetResultType.HALF_LOST, 2.0, 1),
         leg(BetResultType.WINNER, 1.8, 2),


### PR DESCRIPTION
## Summary
Fixes the BB all-winners settlement path so it honours the gross return the pricing engine fixed at placement (`users_bets.return_amount` in consumer schemas), instead of recomputing as `decimal × stake`.

### Why
On some BB rows, `users_bets.decimal × stake ≠ users_bets.return_amount` (root cause unrelated; the drift exists). Honouring `return_amount` verbatim eliminates the discrepancy and makes the displayed Potential Payout match the price the player agreed to.

### Breaking changes (BB path only)
- `BetSettings.decimal` → `BetSettings.stored_payout`
- `BetCalculator.decimal` field → `BetCalculator.stored_payout`
- `processBetBuilderBet(selections, decimal)` → `processBetBuilderBet(selections, stored_payout)`
- All-winners returns `stored_payout` verbatim (no `× stake`)
- Error message: `decimal must be > 0` → `stored_payout must be > 0`

Void-recalc, all-void refund, any-loser, and half_won/half_lost paths are unchanged.

## Test plan
- [x] `npx jest src/tests/BetCalculator/betBuilder.test.ts` — 11/11 pass
- [x] `npx jest src/tests/BetCalculator` — 141/141 pass
- [x] `npx tsc` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)