### PR TITLE
feat(1.0.121): BB 2-leg single-survivor pays at survivor's straight price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.120",
+  "version": "1.0.121",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bet-calculator.class.ts
+++ b/src/BetCalculator/bet-calculator.class.ts
@@ -1743,6 +1743,7 @@ export class BetCalculator {
     let no_of_voids = 0;
     let no_of_losers = 0;
     const voided_odds: number[] = [];
+    const surviving_odds: number[] = [];
 
     for (const leg of selections) {
       const result = leg.result;
@@ -1750,13 +1751,16 @@ export class BetCalculator {
 
       if (result === BetResultType.WINNER) {
         no_of_winners++;
+        surviving_odds.push(odd);
       } else if (result === BetResultType.VOID) {
         no_of_voids++;
         voided_odds.push(odd);
-      } else if (result === BetResultType.HALF_WON || result === BetResultType.HALF_LOST) {
-        // Half-result legs count as winners; their effective-odd reduction is
-        // applied below as a separate divisor on the BB combined price.
+      } else if (result === BetResultType.HALF_WON) {
         no_of_winners++;
+        surviving_odds.push(odd / 2);
+      } else if (result === BetResultType.HALF_LOST) {
+        no_of_winners++;
+        surviving_odds.push(0.5);
       } else if (result === BetResultType.LOSER) {
         no_of_losers++;
       }
@@ -1801,13 +1805,19 @@ export class BetCalculator {
       throw new Error(`Bet Builder stake must be > 0 (got ${stake})`);
     }
 
-    // All winners (no voids) → honour the stored gross return verbatim.
     let payout: number;
-    if (no_of_voids === 0 && no_of_winners === selections.length) {
+    if (selections.length === 2 && no_of_winners === 1 && no_of_voids === 1) {
+      // 2-leg BB with 1 void → the bet collapses to a single on the surviving
+      // leg. BB margin/correlation no longer applies; pay the survivor's
+      // straight price (half-result legs use their effective odd, populated
+      // above as `odd/2` for half_won and `0.5` for half_lost).
+      payout = surviving_odds[0] * stake;
+    } else if (no_of_voids === 0 && no_of_winners === selections.length) {
+      // All winners (no voids) → honour the stored gross return verbatim.
       payout = stored_payout;
     } else {
-      // Mix of winners + voids → strip voided leg odds from the BB combined
-      // price. new_odds = (stored_payout / stake) / ∏ voided_odds.
+      // Mix of winners + voids on a 3+ leg BB → strip voided leg odds from the
+      // BB combined price. new_odds = (stored_payout / stake) / ∏ voided_odds.
       const bb_combined = stored_payout / stake;
       const void_product = voided_odds.reduce((acc, o) => acc * (o > 0 ? o : 1), 1);
       const new_odds = void_product > 0 ? bb_combined / void_product : 0;

--- a/src/tests/BetCalculator/betBuilder.test.ts
+++ b/src/tests/BetCalculator/betBuilder.test.ts
@@ -32,23 +32,39 @@ const settle = (calculator: BetCalculator, args: { stake: number; stored_payout:
     stored_payout: args.stored_payout,
   });
 
-// Settlement rule (formula B):
-//   all winners              → payout = stored_payout (verbatim)
-//   mix of winners + voids   → new_odds = (stored_payout / stake) / ∏ voided_odds
-//                              payout   = new_odds × stake
-//   any loser                → payout = 0
-//   all voids                → refund stake
-describe('Bet Builder — settlement (formula B: strip voided legs from BB combined)', () => {
+// Settlement rule:
+//   all winners                       → payout = stored_payout (verbatim)
+//   2 legs, 1 winner + 1 void         → payout = surviving_odd × stake (special case)
+//   3+ legs, mix of winners + voids   → formula B: new_odds = (stored_payout / stake) / ∏ voided_odds
+//                                       payout = new_odds × stake
+//   any loser                         → payout = 0
+//   all voids                         → refund stake
+describe('Bet Builder — settlement (2-leg single-survivor + formula B for 3+ legs)', () => {
   const calc = new BetCalculator();
 
-  it('2 legs, 1 void → BB combined ÷ voided leg odd', () => {
-    // BB combined = 3.0, void leg 2.0 → new odds 1.5 → $15
+  it('2 legs, 1 void → settles as single at survivor\'s straight price (ignores BB combined margin)', () => {
+    // BB combined intentionally 2.5 (lower than the no-margin acca 1.5 × 2.0 = 3.0
+    // so the margin is visible). New rule pays survivor's odd × stake = 1.5 × 10 = $15,
+    // NOT formula B's (2.5 / 2.0) × 10 = $12.50.
     const r = settle(calc, {
       stake: 10,
-      stored_payout: 30,
+      stored_payout: 25,
       bets: [leg(BetResultType.VOID, 2.0, 1), leg(BetResultType.WINNER, 1.5, 2)],
     });
     expect(r.return_payout).toBeCloseTo(15, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('2 legs, 1 void (asymmetric fixture distinguishes new rule from formula B)', () => {
+    // stake 10, void odd 4.0, survivor odd 2.0, stored_payout 60 (BB combined 6.0).
+    // New rule: 2.0 × 10 = $20.
+    // Formula B (if regressed): (6.0 / 4.0) × 10 = $15. Asserts we land on the new rule.
+    const r = settle(calc, {
+      stake: 10,
+      stored_payout: 60,
+      bets: [leg(BetResultType.VOID, 4.0, 1), leg(BetResultType.WINNER, 2.0, 2)],
+    });
+    expect(r.return_payout).toBeCloseTo(20, 5);
     expect(r.result_type).toBe(BetResultType.WINNER);
   });
 


### PR DESCRIPTION
## Summary
- 2-leg Bet Builder with 1 voided leg now settles at the surviving leg's straight price (× stake), not formula B over the BB combined price.
- 3+ leg BBs keep formula B unchanged.
- Half-result legs use effective odds in the new branch.

## Why
Formula B \`(stored_payout / stake) / ∏ voided_odds\` leaves residual BB margin baked in when only one leg survives. With a single surviving leg the bet collapses to a single, and the player should be paid the straight price.

Staging Bet #23509 illustrates:
- 2-leg BB, BB combined 5.87, stake R10
- Void leg 1.75, winner 4.75
- Before: R33.54 (formula B)
- After: R47.50 (survivor's odd × stake)

## Tests
- Updated \`betBuilder.test.ts\` 2-leg test to use an asymmetric fixture that distinguishes new rule from formula B.
- Added a second 2-leg test (void odd 4.0, survivor odd 2.0, stored_payout 60) — asserts \$20 (new rule) vs formula B's \$15.
- 3+ leg cases unchanged.
- All 10 BB tests pass; all 140 calculator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)