### PR TITLE
feat(1.0.122): BB single-survivor rule generalised to N legs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.121",
+  "version": "1.0.122",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bet-calculator.class.ts
+++ b/src/BetCalculator/bet-calculator.class.ts
@@ -1711,28 +1711,28 @@ export class BetCalculator {
    * Settle a Bet Builder bet.
    *
    * Rules:
-   *   - any losing leg              → bet loses (payout = 0)
-   *   - all winners, no voids       → payout = stored_payout (the gross return
-   *                                   set by the pricing engine at placement,
-   *                                   stored on users_bets.return_amount). No
-   *                                   recompute — honour the price the player
-   *                                   agreed to.
-   *   - mix of winners + voids      → strip the voided legs from the original
-   *                                   BB combined price:
-   *                                     new_odds = (stored_payout / stake) / ∏ voided_odds
-   *                                     payout   = new_odds × stake
-   *                                   This preserves the correlation-adjusted
-   *                                   price of the surviving legs; multiplying
-   *                                   surviving leg odds directly would discard
-   *                                   the BB margin/correlation the player paid
-   *                                   for at placement.
-   *   - all legs void               → refund stake
+   *   - any losing leg                       → bet loses (payout = 0)
+   *   - all winners, no voids                → payout = stored_payout verbatim
+   *                                            (gross return set by the pricing
+   *                                            engine at placement; stored on
+   *                                            users_bets.return_amount).
+   *   - exactly 1 winner + rest all void     → bet collapses to a single on the
+   *                                            survivor:
+   *                                              payout = win_odd × stake
+   *                                            Applies for any number of legs.
+   *                                            BB margin/correlation no longer
+   *                                            applies once only one leg is in
+   *                                            play.
+   *   - ≥2 winners + ≥1 void                 → strip voided legs from the BB
+   *                                            combined price:
+   *                                              new_odds = (stored_payout / stake) / ∏ voided_odds
+   *                                              payout   = new_odds × stake
+   *                                            Preserves the correlation-adjusted
+   *                                            price of the surviving legs.
+   *   - all legs void                        → refund stake
    *
-   * Half-result legs (relevant only on the void-recalc path) divide their
-   * effective odd into the price the same way a void leg does:
-   *   half_won → odd_decimal × 2     half_lost → ÷ 0.5  ⇒  no change
-   * (a half-result is treated as if its odd was halved at placement; on
-   * recalc we divide out the original odd / 2 the same way.)
+   * Half-result legs use their effective odd in the single-survivor branch:
+   *   half_won → odd / 2     half_lost → 0.5
    *
    * BB has no Rule 4 and no BOG. Boosts (BB_BOOST only) are applied by callers
    * outside this function.
@@ -1806,18 +1806,19 @@ export class BetCalculator {
     }
 
     let payout: number;
-    if (selections.length === 2 && no_of_winners === 1 && no_of_voids === 1) {
-      // 2-leg BB with 1 void → the bet collapses to a single on the surviving
-      // leg. BB margin/correlation no longer applies; pay the survivor's
-      // straight price (half-result legs use their effective odd, populated
+    if (no_of_winners === 1 && no_of_voids === selections.length - 1) {
+      // Exactly one surviving leg (and every other leg voided) → the bet
+      // collapses to a single on the survivor. BB margin/correlation no
+      // longer applies; pay the survivor's straight price. Applies for any
+      // number of legs (half-result legs use their effective odd, populated
       // above as `odd/2` for half_won and `0.5` for half_lost).
       payout = surviving_odds[0] * stake;
     } else if (no_of_voids === 0 && no_of_winners === selections.length) {
       // All winners (no voids) → honour the stored gross return verbatim.
       payout = stored_payout;
     } else {
-      // Mix of winners + voids on a 3+ leg BB → strip voided leg odds from the
-      // BB combined price. new_odds = (stored_payout / stake) / ∏ voided_odds.
+      // ≥2 surviving legs + voids → strip voided leg odds from the BB combined
+      // price. new_odds = (stored_payout / stake) / ∏ voided_odds.
       const bb_combined = stored_payout / stake;
       const void_product = voided_odds.reduce((acc, o) => acc * (o > 0 ? o : 1), 1);
       const new_odds = void_product > 0 ? bb_combined / void_product : 0;

--- a/src/tests/BetCalculator/betBuilder.test.ts
+++ b/src/tests/BetCalculator/betBuilder.test.ts
@@ -33,13 +33,16 @@ const settle = (calculator: BetCalculator, args: { stake: number; stored_payout:
   });
 
 // Settlement rule:
-//   all winners                       → payout = stored_payout (verbatim)
-//   2 legs, 1 winner + 1 void         → payout = surviving_odd × stake (special case)
-//   3+ legs, mix of winners + voids   → formula B: new_odds = (stored_payout / stake) / ∏ voided_odds
-//                                       payout = new_odds × stake
-//   any loser                         → payout = 0
-//   all voids                         → refund stake
-describe('Bet Builder — settlement (2-leg single-survivor + formula B for 3+ legs)', () => {
+//   all winners                          → payout = stored_payout (verbatim)
+//   exactly 1 winner + rest all void     → payout = win_odd × stake
+//                                          (single-survivor — applies for ANY
+//                                          number of legs; bet collapses to a
+//                                          single on the survivor)
+//   ≥2 winners + ≥1 void                 → formula B: new_odds = (stored_payout / stake) / ∏ voided_odds
+//                                          payout = new_odds × stake
+//   any loser                            → payout = 0
+//   all voids                            → refund stake
+describe('Bet Builder — settlement (N-leg single-survivor + formula B for ≥2 survivors)', () => {
   const calc = new BetCalculator();
 
   it('2 legs, 1 void → settles as single at survivor\'s straight price (ignores BB combined margin)', () => {
@@ -82,8 +85,11 @@ describe('Bet Builder — settlement (2-leg single-survivor + formula B for 3+ l
     expect(r.result_type).toBe(BetResultType.WINNER);
   });
 
-  it('3 legs, 2 voids → BB combined ÷ (void1 × void2)', () => {
-    // BB combined 5.4, voids 2.0 × 1.5 = 3.0 → new odds 1.8 → $18
+  it('3 legs, 2 voids (single survivor) → settles at survivor\'s straight price', () => {
+    // Single surviving leg at odd 1.8, stake 10 → payout 1.8 × 10 = $18.
+    // (Fixture has stored_payout 54 = 1.8 × 2.0 × 1.5 × 10, no margin baked
+    // in, so the new rule and formula B coincidentally agree here — the
+    // dedicated asymmetric 3-leg test below proves the rules differ.)
     const r = settle(calc, {
       stake: 10,
       stored_payout: 54,
@@ -94,6 +100,24 @@ describe('Bet Builder — settlement (2-leg single-survivor + formula B for 3+ l
       ],
     });
     expect(r.return_payout).toBeCloseTo(18, 5);
+    expect(r.result_type).toBe(BetResultType.WINNER);
+  });
+
+  it('3 legs, 2 voids — asymmetric fixture distinguishes single-survivor rule from formula B', () => {
+    // stake 10, voids 2.0 + 4.0, survivor 1.5, stored_payout 60 (BB combined
+    // 6.0, deliberately != un-margined acca 1.5 × 2.0 × 4.0 = 12 so the BB
+    // margin/correlation is visible). Single-survivor rule: 1.5 × 10 = $15.
+    // Formula B (regression): (6.0 / 8.0) × 10 = $7.50.
+    const r = settle(calc, {
+      stake: 10,
+      stored_payout: 60,
+      bets: [
+        leg(BetResultType.VOID, 2.0, 1),
+        leg(BetResultType.VOID, 4.0, 2),
+        leg(BetResultType.WINNER, 1.5, 3),
+      ],
+    });
+    expect(r.return_payout).toBeCloseTo(15, 5);
     expect(r.result_type).toBe(BetResultType.WINNER);
   });
 
@@ -113,8 +137,10 @@ describe('Bet Builder — settlement (2-leg single-survivor + formula B for 3+ l
     expect(r.result_type).toBe(BetResultType.WINNER);
   });
 
-  it('6 legs, 5 voids → BB combined ÷ (∏ all 5 voided odds)', () => {
-    // BB combined 33.075 (= 2×1.5×1.8×2.5×1.4×1.75), voids product 18.9 → new odds 1.75 → $17.50
+  it('6 legs, 5 voids (single survivor) → settles at survivor\'s straight price ($17.50)', () => {
+    // Single surviving leg at odd 1.75, stake 10 → payout 1.75 × 10 = $17.50.
+    // (Fixture stored_payout 330.75 has no margin baked in so formula B
+    // would also give $17.50 — assertion unchanged from prior versions.)
     const r = settle(calc, {
       stake: 10,
       stored_payout: 330.75,


### PR DESCRIPTION
## Summary
Generalises the BB single-survivor rule from 2-leg (1.0.121) to any number of legs. If exactly one leg wins and every other leg voids, payout = `win_odd × stake` regardless of total leg count.

Cases with ≥2 surviving legs continue to use formula B `(stored_payout / stake) / ∏ voided_odds`.

## Tests
- New asymmetric 3-leg test (voids 2.0 + 4.0, survivor 1.5, stored_payout 60) — asserts $15 (single-survivor rule) vs formula B's $7.50.
- Existing 3-leg & 6-leg single-survivor tests get clearer descriptions; assertions unchanged (their fixtures coincidentally agree under both rules because no margin was baked in).
- All 11 BB tests pass; 141 calculator tests total pass.

## Companion rollout
Following the 1.0.121 pattern: ELBAPI dep bump only, CMSEB helper edit + dep bump. PRs forthcoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)