### PR TITLE
feat(1.0.123): add /ui subpath with BetBuilder React components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 package*.json
 test
 views
+src/ui

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@swc/jest": "^0.2.39",
         "@types/jest": "^29.5.14",
         "@types/node": "^18.11.17",
+        "@types/react": "^18.3.28",
+        "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.56.0",
@@ -33,6 +35,8 @@
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -1775,6 +1779,34 @@
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -3010,6 +3042,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6079,7 +6118,6 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6920,6 +6958,33 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7174,6 +7239,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -9457,6 +9532,29 @@
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -10346,6 +10444,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -12564,7 +12668,6 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -13178,6 +13281,25 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -13349,6 +13471,15 @@
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      }
+    },
+    "scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,37 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.122",
+  "version": "1.0.123",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./ui": {
+      "types": "./dist/ui/index.d.ts",
+      "default": "./dist/ui/index.js"
+    },
+    "./ui/styles.css": "./dist/ui/styles.css",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "react-dom": { "optional": true }
+  },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "rimraf dist && tsc",
+    "build": "rimraf dist && tsc && npm run build:ui",
+    "build:ui": "tsc -p tsconfig.ui.json && node ./scripts/copy-ui-assets.js",
     "lint": "eslint src/**/*.ts",
     "test": "jest --color --verbose",
     "test:coverage": "jest --coverage --color --verbose",
@@ -43,6 +67,8 @@
     "@swc/jest": "^0.2.39",
     "@types/jest": "^29.5.14",
     "@types/node": "^18.11.17",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.56.0",
@@ -53,6 +79,8 @@
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",

--- a/scripts/copy-ui-assets.js
+++ b/scripts/copy-ui-assets.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+const srcDir = path.join(__dirname, "..", "src", "ui");
+const outDir = path.join(__dirname, "..", "dist", "ui");
+
+function copyAssets(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      copyAssets(src);
+      continue;
+    }
+    if (!/\.(css|d\.ts)$/.test(entry.name)) continue;
+    const rel = path.relative(srcDir, src);
+    const dest = path.join(outDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+}
+
+if (!fs.existsSync(outDir)) {
+  console.error("dist/ui not found — run `tsc -p tsconfig.ui.json` first");
+  process.exit(1);
+}
+
+copyAssets(srcDir);
+console.log("Copied CSS assets to dist/ui");

--- a/src/ui/BetBuilderMarkets.tsx
+++ b/src/ui/BetBuilderMarkets.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { TabsSelect } from "./TabsSelect";
+import { MarketSelections } from "./MarketSelections";
+import { EmptyState } from "./EmptyState";
+import type {
+  BetBuilderEvent,
+  BetBuilderMarket,
+  BetBuilderOption,
+  SelectionClickHandler,
+} from "./types";
+
+interface SingleMarketProps {
+  market: BetBuilderMarket;
+  selectedBetIds: Set<string>;
+  onSelectionClick: SelectionClickHandler;
+}
+
+const SingleMarket = ({ market, selectedBetIds, onSelectionClick }: SingleMarketProps) => {
+  const groups = market.selections ?? [];
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const activeGroup = groups[selectedIdx];
+
+  if (!activeGroup) return null;
+
+  const columnsRaw = market.columns ?? 1;
+  const columnList = Array.isArray(columnsRaw)
+    ? columnsRaw
+    : Array.from({ length: Number(columnsRaw) || 1 }, (_, i) => `column${i + 1}`);
+
+  let autoIdx = 0;
+  const groupedByColumn = activeGroup.options.reduce<Record<string, BetBuilderOption[]>>(
+    (acc, option) => {
+      let col = option.column;
+      if (!col || col === "0" || col === 0) {
+        col = columnList[autoIdx % columnList.length];
+        autoIdx += 1;
+      }
+      const key = String(col);
+      if (!acc[key]) acc[key] = [];
+      acc[key].push({ ...option, column: col });
+      return acc;
+    },
+    {}
+  );
+
+  const columnGroups = Object.values(groupedByColumn);
+
+  return (
+    <section className="bb-ui__market">
+      <header className="bb-ui__market-header">
+        <h3 className="bb-ui__market-name">{market.name}</h3>
+        {groups.length > 1 ? (
+          <TabsSelect
+            data={groups.map((g, i) => ({ id: i, label: g.name }))}
+            selectedItemId={selectedIdx}
+            onChange={(t) => setSelectedIdx(Number(t.id))}
+          />
+        ) : null}
+      </header>
+      <div
+        className="bb-ui__market-grid"
+        style={{ gridTemplateColumns: `repeat(${columnGroups.length || 1}, minmax(0, 1fr))` }}
+      >
+        {columnGroups.map((column, idx) => (
+          <MarketSelections
+            key={idx}
+            market={market}
+            group={{ ...activeGroup, options: column }}
+            selectedBetIds={selectedBetIds}
+            onSelectionClick={onSelectionClick}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+interface BetBuilderMarketsProps {
+  markets: BetBuilderMarket[] | null | undefined;
+  event: BetBuilderEvent;
+  selectedBetIds: Set<string>;
+  onSelectionClick: SelectionClickHandler;
+  emptyMessage?: string;
+}
+
+export const BetBuilderMarkets = ({
+  markets,
+  event: _event,
+  selectedBetIds,
+  onSelectionClick,
+  emptyMessage = "No markets available",
+}: BetBuilderMarketsProps) => {
+  if (!markets?.length) return <EmptyState message={emptyMessage} />;
+
+  return (
+    <div className="bb-ui__markets">
+      {markets.map((market) => (
+        <SingleMarket
+          key={String(market.id)}
+          market={market}
+          selectedBetIds={selectedBetIds}
+          onSelectionClick={onSelectionClick}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/ui/EmptyState.tsx
+++ b/src/ui/EmptyState.tsx
@@ -1,0 +1,7 @@
+interface EmptyStateProps {
+  message: string;
+}
+
+export const EmptyState = ({ message }: EmptyStateProps) => (
+  <div className="bb-ui__empty">{message}</div>
+);

--- a/src/ui/MarketSelections.tsx
+++ b/src/ui/MarketSelections.tsx
@@ -1,0 +1,56 @@
+import type {
+  BetBuilderMarket,
+  BetBuilderOption,
+  BetBuilderSelectionGroup,
+  SelectionClickHandler,
+} from "./types";
+
+interface MarketSelectionsProps {
+  market: BetBuilderMarket;
+  group: BetBuilderSelectionGroup;
+  selectedBetIds: Set<string>;
+  onSelectionClick: SelectionClickHandler;
+}
+
+function getOptionKey(option: BetBuilderOption): string {
+  const id = option.bet_id ?? option.id;
+  return id == null ? "" : String(id);
+}
+
+function formatOdds(odds: unknown): string {
+  if (odds == null) return "-";
+  const num = typeof odds === "number" ? odds : Number(odds);
+  if (Number.isNaN(num)) return String(odds);
+  return num.toFixed(2);
+}
+
+export const MarketSelections = ({
+  market,
+  group,
+  selectedBetIds,
+  onSelectionClick,
+}: MarketSelectionsProps) => {
+  if (!group?.options?.length) return null;
+
+  return (
+    <div className="bb-ui__selections">
+      {group.options.map((option) => {
+        const key = getOptionKey(option);
+        const isSelected = key !== "" && selectedBetIds.has(key);
+        const label = group.show_name === false ? option.name : `${group.name} - ${option.name}`;
+
+        return (
+          <button
+            type="button"
+            key={`${key}-${option.name}`}
+            className={`bb-ui__selection${isSelected ? " bb-ui__selection--selected" : ""}`}
+            onClick={() => onSelectionClick({ option, market, group })}
+          >
+            <span className="bb-ui__selection-name">{label}</span>
+            <span className="bb-ui__selection-odds">{formatOdds(option.odds)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/ui/TabsSelect.tsx
+++ b/src/ui/TabsSelect.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+interface Tab {
+  id: string | number;
+  label: string;
+}
+
+interface TabsSelectProps {
+  data: Tab[];
+  selectedItemId?: string | number;
+  onChange?: (tab: Tab) => void;
+  placeholder?: string;
+}
+
+export const TabsSelect = ({ data, selectedItemId, onChange }: TabsSelectProps) => {
+  const initial = data?.find((t) => t.id === selectedItemId) ?? data?.[0];
+  const [selected, setSelected] = useState<Tab | undefined>(initial);
+
+  useEffect(() => {
+    if (selectedItemId == null) return;
+    const next = data?.find((t) => t.id === selectedItemId);
+    if (next) setSelected(next);
+  }, [selectedItemId, data]);
+
+  const handleClick = (tab: Tab) => {
+    setSelected(tab);
+    onChange?.(tab);
+  };
+
+  if (!data?.length) return null;
+
+  return (
+    <ul className="bb-ui__tabs">
+      {data.map((tab) => {
+        const isActive = selected?.id === tab.id;
+        return (
+          <li
+            key={`${tab.id}-${tab.label}`}
+            className={`bb-ui__tab${isActive ? " bb-ui__tab--active" : ""}`}
+            onClick={() => handleClick(tab)}
+          >
+            {tab.label}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,12 @@
+export { BetBuilderMarkets } from "./BetBuilderMarkets";
+export { MarketSelections } from "./MarketSelections";
+export { TabsSelect } from "./TabsSelect";
+export { EmptyState } from "./EmptyState";
+export type {
+  BetBuilderEvent,
+  BetBuilderMarket,
+  BetBuilderOption,
+  BetBuilderSelectionGroup,
+  SelectionClickHandler,
+  SelectionClickPayload,
+} from "./types";

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,0 +1,146 @@
+/* @swiftyglobal/swifty-shared/ui — themable via CSS variables.
+ * Consumers override these in a parent scope (e.g. `.bb-ui-cms { --bb-selection-bg-selected: #7a6fbe; }`).
+ */
+
+.bb-ui__markets,
+.bb-ui__market,
+.bb-ui__market-grid,
+.bb-ui__selections,
+.bb-ui__tabs {
+  --bb-bg: #ffffff;
+  --bb-border: #e4e8ee;
+  --bb-radius: 6px;
+  --bb-text: #2e3a49;
+  --bb-text-muted: #7b8794;
+  --bb-text-selected: #ffffff;
+
+  --bb-selection-bg: #f5f7fa;
+  --bb-selection-bg-hover: #ecf0f5;
+  --bb-selection-bg-selected: #7a6fbe;
+  --bb-selection-border: var(--bb-border);
+
+  --bb-tab-bg: transparent;
+  --bb-tab-bg-active: #ecf0f5;
+  --bb-tab-text: var(--bb-text);
+  --bb-tab-text-active: var(--bb-text);
+
+  --bb-gap: 8px;
+}
+
+.bb-ui__markets {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--bb-text);
+  font-family: inherit;
+}
+
+.bb-ui__market {
+  background: var(--bb-bg);
+  border: 1px solid var(--bb-border);
+  border-radius: var(--bb-radius);
+  padding: 12px;
+}
+
+.bb-ui__market-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.bb-ui__market-name {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.bb-ui__market-grid {
+  display: grid;
+  gap: var(--bb-gap);
+}
+
+.bb-ui__selections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bb-gap);
+}
+
+.bb-ui__selection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--bb-radius);
+  border: 1px solid var(--bb-selection-border);
+  background: var(--bb-selection-bg);
+  color: var(--bb-text);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.bb-ui__selection:hover {
+  background: var(--bb-selection-bg-hover);
+}
+
+.bb-ui__selection--selected {
+  background: var(--bb-selection-bg-selected);
+  color: var(--bb-text-selected);
+  border-color: var(--bb-selection-bg-selected);
+}
+
+.bb-ui__selection--selected:hover {
+  background: var(--bb-selection-bg-selected);
+}
+
+.bb-ui__selection-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bb-ui__selection-odds {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.bb-ui__tabs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.bb-ui__tab {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bb-tab-bg);
+  color: var(--bb-tab-text);
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  user-select: none;
+}
+
+.bb-ui__tab--active {
+  background: var(--bb-tab-bg-active);
+  color: var(--bb-tab-text-active);
+  border-color: var(--bb-border);
+}
+
+.bb-ui__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--bb-text-muted);
+  font-size: 13px;
+}

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,0 +1,37 @@
+export interface BetBuilderOption {
+  bet_id?: string | number;
+  id?: string | number;
+  name: string;
+  odds?: number | string;
+  column?: string | number;
+  [key: string]: unknown;
+}
+
+export interface BetBuilderSelectionGroup {
+  name: string;
+  show_name?: boolean;
+  options: BetBuilderOption[];
+}
+
+export interface BetBuilderMarket {
+  id: string | number;
+  name: string;
+  columns?: number | string[];
+  selections: BetBuilderSelectionGroup[];
+  round_to_flat?: number;
+  show_name?: boolean;
+}
+
+export interface BetBuilderEvent {
+  event_id: string | number;
+  event_name: string;
+  start_time?: string | number;
+}
+
+export interface SelectionClickPayload {
+  option: BetBuilderOption;
+  market: BetBuilderMarket;
+  group: BetBuilderSelectionGroup;
+}
+
+export type SelectionClickHandler = (payload: SelectionClickPayload) => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/ui"
   ]
 }

--- a/tsconfig.ui.json
+++ b/tsconfig.ui.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "declaration": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "pretty": true,
+    "outDir": "dist/ui",
+    "rootDir": "src/ui",
+    "lib": ["DOM", "DOM.Iterable", "ES2018"],
+    "typeRoots": ["node_modules/@types"]
+  },
+  "include": ["src/ui"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a new host-agnostic React UI subpath `@swiftyglobal/swifty-shared/ui` consumable from both `SwiftyGamingFront` and `SwiftyPredictionsCMSWebsite`.
- First consumer is the new "Build Bet Builder" modal in the CMS (companion PR `SwiftyPredictionsCMSWebsite` — opening next). `SwiftyGamingFront` can later re-export its `BetBuilderMarkets` from here.

## What's exported (from `/ui`)

- `BetBuilderMarkets` — markets browser; takes `markets`, `event`, `selectedBetIds`, `onSelectionClick({option, market, group})`.
- `MarketSelections` — single market's selection grid. Pure presentational; no Redux/socket deps.
- `TabsSelect` — minimal tab strip (no Carousel/mobile fork).
- `EmptyState` — minimal empty message.
- types — `BetBuilderMarket`, `BetBuilderOption`, `BetBuilderSelectionGroup`, `SelectionClickHandler`, etc.

## Theming

CSS variables exposed: `--bb-bg`, `--bb-border`, `--bb-selection-bg`, `--bb-selection-bg-hover`, `--bb-selection-bg-selected`, `--bb-text`, `--bb-text-selected`, `--bb-tab-bg-active`, etc. Consumers override in a parent scope (e.g. `.bb-ui-cms { --bb-selection-bg-selected: #7a6fbe; }`).

## Infrastructure changes

- **New `tsconfig.ui.json`** — `jsx: react-jsx`, `lib: [DOM, DOM.Iterable, ES2018]`, `outDir: dist/ui`. Includes only `src/ui`.
- **Main `tsconfig.json`** now excludes `src/ui` so the existing backend build stays JSX-free.
- **`scripts/copy-ui-assets.js`** — post-tsc step that copies `.css` into `dist/ui` (tsc doesn't handle CSS).
- **`package.json`**:
  - `version` bumped to `1.0.123`
  - `exports` map: `.` (existing backend entry), `./ui`, `./ui/styles.css`, `./package.json`
  - `files: ["dist"]`
  - `react` + `react-dom` as **optional** peerDeps (backend consumers ignore them)
  - `sideEffects: ["*.css"]` so bundlers don't tree-shake CSS imports
  - `build` script: `tsc && tsc -p tsconfig.ui.json && node ./scripts/copy-ui-assets.js`

## Compatibility

- Existing root import (`import { ... } from "@swiftyglobal/swifty-shared"`) is unchanged — same `dist/index.js`. Backend consumers (SwiftyGamingBackend, CMSEB) keep working with no changes.
- React is a peer dep, marked optional — backend installs don't warn.
- The `/ui` path is purely additive.

## Publish

After merge:
```bash
git checkout master && git pull
npm publish
```
Then bump consumers:
- `SwiftyPredictionsCMSWebsite/package.json` — already on `^1.0.22`, caret picks up `1.0.123`. Run `npm install` to refresh lockfile.
- `SwiftyGamingFront/package.json` — already on `^1.0.110`, same.

## Test plan

- [ ] `npm install` from a clean tree — no peer-dep warnings on backend consumers (CMSEB, SwiftyGamingBackend).
- [ ] `npm run build` — produces `dist/` (backend) + `dist/ui/` (UI) with .d.ts, .js, .map, and styles.css.
- [ ] In a consumer project: `import { BetBuilderMarkets } from "@swiftyglobal/swifty-shared/ui"` resolves; `import "@swiftyglobal/swifty-shared/ui/styles.css"` resolves.
- [ ] Backend consumer (e.g. SwiftyGamingBackend) still imports root types correctly: `import { RedisPrefixes } from "@swiftyglobal/swifty-shared"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)