### PR TITLE
feat(BetCalculator): add acca-boost tier resolver [5063]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.123",
+  "version": "1.0.124",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/accaBoost.ts
+++ b/src/BetCalculator/accaBoost.ts
@@ -1,0 +1,208 @@
+/**
+ * Acca Boost tier resolver — Trello [5063].
+ *
+ * Pure functions shared by the auto-settle worker (swiftyPredictionsELBAPI)
+ * and the manual-settle CMS (SwiftyPredictionsCMSEB). The repos used to keep
+ * near-identical copies; consolidating here keeps tier-rule changes in one
+ * place and guarantees preview / persist parity.
+ *
+ * Design rules:
+ *  - No DB access. Each repo passes its own loaded config in.
+ *  - No logging side-effects.
+ *  - When NO leg is void/pushed, keep the placement-time tier (snapshot or
+ *    legacy placement bet_type) verbatim — preview paths run before any leg
+ *    is graded and must not downgrade.
+ *  - When at least one leg IS void/pushed, recompute the tier from the
+ *    effective fold (graded legs only: winner/loser/half_won/half_lost).
+ *  - Snapshot percentage caps the recomputed tier — voids may only downgrade.
+ *  - Below-table floor: if effective fold < smallest configured tier, use
+ *    the lowest configured tier's percentage.
+ */
+
+/** Single tier entry from `settings_v2.acca_boost_bet_types`. */
+export interface AccaBoostTier {
+  bet_type: string; // "double" | "treble" | "fold4" | ... | "foldN"
+  percentage_boost: number | string;
+}
+
+/** Live acca config loaded from settings_v2 by each consumer repo. */
+export interface AccaBoostConfig {
+  enabled: boolean;
+  bet_types: AccaBoostTier[];
+  max_award?: number;
+  // Other settings_v2 fields (minimum_odds, all_markets, sports_markets) are
+  // not consulted by the resolver — they gate at the orchestrator level.
+}
+
+/** Placement-time snapshot stored on users_bets.acca_boost_rules. */
+export interface AccaRulesSnapshot {
+  percentage_boost: number | string;
+  max_award?: number | string;
+  // applied_percentage_boost / applied_max_award are trader-override audit
+  // fields surfaced elsewhere; not consulted by the resolver.
+  [key: string]: unknown;
+}
+
+/** Leg shape consumed by the resolver — only `result` is read. */
+export interface BoostLeg {
+  result?: string | null;
+  [key: string]: unknown;
+}
+
+/** Resolver output. `effective_fold` is null when the no-void path was taken. */
+export interface AccaTierResolution {
+  percentage: number;
+  max_award: number;
+  effective_fold: number | null;
+}
+
+const GRADED_RESULTS = new Set(['winner', 'loser', 'half_won', 'half_lost']);
+const VOID_RESULTS = new Set(['void', 'pushed', 'push']);
+
+/**
+ * Map an effective fold count to the bet_type key used by acca_boost_bet_types.
+ * Mirrors how users_bets_multiple.bet_type is stored at placement
+ * (SGB combinationsGenerator.service.ts).
+ */
+export function effectiveBetTypeKey(fold: number): string | null {
+  const n = Number(fold);
+  if (!Number.isFinite(n) || n < 2) return null;
+  if (n === 2) return 'double';
+  if (n === 3) return 'treble';
+  return `fold${n}`;
+}
+
+/**
+ * Parse a tier key ('double' | 'treble' | 'foldN') back to its fold count.
+ * Used to find the smallest configured tier as a floor when effective fold
+ * drops below the configured range.
+ */
+export function betTypeKeyToFold(key: string): number | null {
+  if (typeof key !== 'string') return null;
+  if (key === 'double') return 2;
+  if (key === 'treble') return 3;
+  const m = /^fold(\d+)$/.exec(key);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * True iff any leg currently has a void/pushed result.
+ */
+export function hasAnyVoidLeg(legs: BoostLeg[] | null | undefined): boolean {
+  if (!Array.isArray(legs)) return false;
+  return legs.some((l) => VOID_RESULTS.has(String(l?.result ?? '').toLowerCase()));
+}
+
+/**
+ * Count graded legs (winner/loser/half_won/half_lost). Voids and pushed
+ * reduce the effective fold so they are excluded. Used as the input to
+ * `effectiveBetTypeKey`.
+ */
+export function countEffectiveFold(legs: BoostLeg[] | null | undefined): number {
+  if (!Array.isArray(legs)) return 0;
+  return legs.reduce((acc, leg) => (GRADED_RESULTS.has(String(leg?.result ?? '').toLowerCase()) ? acc + 1 : acc), 0);
+}
+
+/**
+ * MySQL JSON columns may come back as either an already-parsed object or a raw
+ * string depending on the driver mode. Normalise to an object (or null) so the
+ * caller can fall back to live config when the snapshot is missing/unparseable.
+ *
+ * Generic helper — used for acca_boost_rules, bb_boost_rules, lucky_boost_rules.
+ */
+export function parseRulesSnapshot<T extends Record<string, unknown> = Record<string, unknown>>(
+  raw: unknown,
+): T | null {
+  if (raw === null || raw === undefined || raw === '') return null;
+  if (typeof raw === 'object') return raw as T;
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResolveAccaTierParams {
+  /** Live acca boost config from settings_v2. May be null if config is wiped/disabled. */
+  config: AccaBoostConfig | null | undefined;
+  /** Graded legs from user_bets_single (or equivalent). */
+  bets: BoostLeg[] | null | undefined;
+  /** Placement-time rules snapshot from users_bets.acca_boost_rules. */
+  snapshot?: AccaRulesSnapshot | null;
+  /**
+   * Placement bet_type (e.g. "fold6", "treble"). Used as a fallback for
+   * legacy bets that have no snapshot — match against live config to find
+   * the placement tier.
+   */
+  placementBetType?: string | null;
+}
+
+/**
+ * Re-evaluate the acca boost tier at settlement.
+ *
+ * Returns null when neither snapshot nor live config can produce a usable
+ * percentage. See module-level doc for the full semantics.
+ */
+export function resolveAccaTier(params: ResolveAccaTierParams): AccaTierResolution | null {
+  const { config, bets, snapshot, placementBetType } = params;
+
+  const snapshotPct = snapshot && Number(snapshot.percentage_boost) > 0 ? Number(snapshot.percentage_boost) : 0;
+  const snapshotMax = snapshot && Number(snapshot.max_award) > 0 ? Number(snapshot.max_award) : 0;
+
+  const hasLiveTiers = !!(config && config.enabled && Array.isArray(config.bet_types) && config.bet_types.length > 0);
+
+  // No voids → keep placement tier verbatim. This is the OPEN-bet preview path
+  // and the all-winners settle path; both should match what the player was
+  // promised at placement.
+  if (!hasAnyVoidLeg(bets)) {
+    if (snapshotPct > 0) {
+      const finalMax = snapshotMax > 0 ? snapshotMax : hasLiveTiers ? Number(config!.max_award) || 0 : 0;
+      return { percentage: snapshotPct, max_award: finalMax, effective_fold: null };
+    }
+    if (!hasLiveTiers || !placementBetType) return null;
+    const cleanType = String(placementBetType).replace('bet_slip_place_', '');
+    const match = config!.bet_types.find((bt) => bt.bet_type === cleanType);
+    if (!match) return null;
+    return {
+      percentage: Number(match.percentage_boost) || 0,
+      max_award: Number(config!.max_award) || 0,
+      effective_fold: null,
+    };
+  }
+
+  // At least one void: recompute by effective fold.
+  const effectiveFold = countEffectiveFold(bets);
+
+  let tierPct = 0;
+  if (hasLiveTiers) {
+    const key = effectiveBetTypeKey(effectiveFold);
+    let match = key ? config!.bet_types.find((bt) => bt.bet_type === key) : null;
+    if (!match) {
+      // Below-table floor: use the lowest configured fold's percentage.
+      const sorted = config!.bet_types
+        .map((bt) => ({ ...bt, _fold: betTypeKeyToFold(bt.bet_type) }))
+        .filter((bt): bt is AccaBoostTier & { _fold: number } => bt._fold !== null)
+        .sort((a, b) => a._fold - b._fold);
+      if (sorted.length > 0 && effectiveFold < sorted[0]._fold) {
+        match = sorted[0];
+      }
+    }
+    if (match) tierPct = Number(match.percentage_boost) || 0;
+  }
+
+  if (!hasLiveTiers) {
+    if (snapshotPct <= 0) return null;
+    return { percentage: snapshotPct, max_award: snapshotMax, effective_fold: effectiveFold };
+  }
+
+  // Cap by snapshot when present — voids may only downgrade, never upgrade.
+  let finalPct = tierPct;
+  if (snapshotPct > 0 && finalPct > snapshotPct) finalPct = snapshotPct;
+
+  if (finalPct <= 0) return null;
+
+  const finalMax = snapshotMax > 0 ? snapshotMax : Number(config!.max_award) || 0;
+  return { percentage: finalPct, max_award: finalMax, effective_fold: effectiveFold };
+}

--- a/src/BetCalculator/index.ts
+++ b/src/BetCalculator/index.ts
@@ -1,2 +1,3 @@
 export * from './bet-calculator.class';
 export * from './bet-calculator.helper';
+export * from './accaBoost';

--- a/src/tests/BetCalculator/accaBoost.test.ts
+++ b/src/tests/BetCalculator/accaBoost.test.ts
@@ -1,0 +1,287 @@
+import type { AccaBoostConfig, BoostLeg } from '../../BetCalculator/accaBoost';
+import {
+  resolveAccaTier,
+  effectiveBetTypeKey,
+  betTypeKeyToFold,
+  hasAnyVoidLeg,
+  countEffectiveFold,
+  parseRulesSnapshot,
+} from '../../BetCalculator/accaBoost';
+
+// Trello [5063]: Acca boost tier must reflect EFFECTIVE fold after voids.
+// A 7-fold placed at 15% with 2 voids → 5-fold tier → 10%.
+
+const sevenTierConfig: AccaBoostConfig = {
+  enabled: true,
+  max_award: 1000,
+  bet_types: [
+    { bet_type: 'fold5', percentage_boost: 10 },
+    { bet_type: 'fold6', percentage_boost: 12 },
+    { bet_type: 'fold7', percentage_boost: 15 },
+  ],
+};
+
+function legs({
+  winners = 0,
+  losers = 0,
+  voids = 0,
+}: { winners?: number; losers?: number; voids?: number } = {}): BoostLeg[] {
+  const out: BoostLeg[] = [];
+  for (let i = 0; i < winners; i++) out.push({ result: 'winner' });
+  for (let i = 0; i < losers; i++) out.push({ result: 'loser' });
+  for (let i = 0; i < voids; i++) out.push({ result: 'void' });
+  return out;
+}
+
+describe('effectiveBetTypeKey - fold → bet_type key', () => {
+  it("maps 2 to 'double'", () => expect(effectiveBetTypeKey(2)).toBe('double'));
+  it("maps 3 to 'treble'", () => expect(effectiveBetTypeKey(3)).toBe('treble'));
+  it("maps 4 to 'fold4'", () => expect(effectiveBetTypeKey(4)).toBe('fold4'));
+  it("maps 7 to 'fold7'", () => expect(effectiveBetTypeKey(7)).toBe('fold7'));
+  it('returns null for fold < 2', () => {
+    expect(effectiveBetTypeKey(1)).toBeNull();
+    expect(effectiveBetTypeKey(0)).toBeNull();
+  });
+  it('returns null for non-numeric input', () => {
+    expect(effectiveBetTypeKey(NaN)).toBeNull();
+  });
+});
+
+describe('betTypeKeyToFold - inverse mapping', () => {
+  it("'double' → 2", () => expect(betTypeKeyToFold('double')).toBe(2));
+  it("'treble' → 3", () => expect(betTypeKeyToFold('treble')).toBe(3));
+  it("'fold7' → 7", () => expect(betTypeKeyToFold('fold7')).toBe(7));
+  it('returns null for unknown keys', () => expect(betTypeKeyToFold('quadruple')).toBeNull());
+});
+
+describe('hasAnyVoidLeg', () => {
+  it('detects void', () => expect(hasAnyVoidLeg(legs({ winners: 4, voids: 1 }))).toBe(true));
+  it('detects pushed', () => expect(hasAnyVoidLeg([{ result: 'winner' }, { result: 'pushed' }])).toBe(true));
+  it('false for all winners', () => expect(hasAnyVoidLeg(legs({ winners: 5 }))).toBe(false));
+  it('false for empty / null', () => {
+    expect(hasAnyVoidLeg([])).toBe(false);
+    expect(hasAnyVoidLeg(null)).toBe(false);
+    expect(hasAnyVoidLeg(undefined)).toBe(false);
+  });
+});
+
+describe('countEffectiveFold', () => {
+  it('counts winners + losers + half_won + half_lost', () => {
+    const arr: BoostLeg[] = [
+      { result: 'winner' },
+      { result: 'winner' },
+      { result: 'loser' },
+      { result: 'half_won' },
+      { result: 'half_lost' },
+      { result: 'void' },
+      { result: 'pushed' },
+    ];
+    expect(countEffectiveFold(arr)).toBe(5);
+  });
+  it('returns 0 for empty / null', () => {
+    expect(countEffectiveFold([])).toBe(0);
+    expect(countEffectiveFold(null)).toBe(0);
+  });
+});
+
+describe('parseRulesSnapshot', () => {
+  it('returns null for null/undefined/empty', () => {
+    expect(parseRulesSnapshot(null)).toBeNull();
+    expect(parseRulesSnapshot(undefined)).toBeNull();
+    expect(parseRulesSnapshot('')).toBeNull();
+  });
+  it('passes through an object', () => {
+    const obj = { percentage_boost: 5, max_award: 100 };
+    expect(parseRulesSnapshot(obj)).toBe(obj);
+  });
+  it('parses a JSON string', () => {
+    const obj = { percentage_boost: 5, max_award: 100 };
+    expect(parseRulesSnapshot(JSON.stringify(obj))).toEqual(obj);
+  });
+  it('returns null on malformed JSON', () => {
+    expect(parseRulesSnapshot('{not-json')).toBeNull();
+  });
+  it('returns null when JSON parses to a primitive', () => {
+    expect(parseRulesSnapshot('42')).toBeNull();
+    expect(parseRulesSnapshot('"foo"')).toBeNull();
+  });
+});
+
+describe('resolveAccaTier - no-void path (placement tier kept)', () => {
+  it('snapshot present, no voids → keep snapshot %', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 7 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier).toEqual({ percentage: 15, max_award: 1000, effective_fold: null });
+  });
+
+  it('snapshot still wins over live tier in all-win path', () => {
+    // Snapshot 8% even though live fold7 is 15% — placement promise wins.
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 7 }),
+      snapshot: { percentage_boost: 8, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(8);
+    expect(tier!.effective_fold).toBeNull();
+  });
+
+  it('legacy bet (no snapshot), no voids → live config matched by placement bet_type', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 6 }),
+      snapshot: null,
+      placementBetType: 'fold6',
+    });
+    expect(tier!.percentage).toBe(12);
+    expect(tier!.effective_fold).toBeNull();
+  });
+
+  it('legacy bet, no voids, no placementBetType → null', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 6 }),
+      snapshot: null,
+    });
+    expect(tier).toBeNull();
+  });
+
+  it('legacy bet, no voids, placement tier not in config → null', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 4 }),
+      snapshot: null,
+      placementBetType: 'fold4',
+    });
+    expect(tier).toBeNull();
+  });
+
+  it('snapshot max_award wins over live max_award (no voids)', () => {
+    const cfg: AccaBoostConfig = { ...sevenTierConfig, max_award: 100 };
+    const tier = resolveAccaTier({
+      config: cfg,
+      bets: legs({ winners: 7 }),
+      snapshot: { percentage_boost: 15, max_award: 5000 },
+    });
+    expect(tier!.max_award).toBe(5000);
+  });
+
+  it('uses live max_award when snapshot has no cap (no voids)', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 7 }),
+      snapshot: { percentage_boost: 15 },
+    });
+    expect(tier!.max_award).toBe(1000);
+  });
+});
+
+describe('resolveAccaTier - void-aware tier recompute', () => {
+  it('7-fold placed at 15%, 2 voids → effective 5-fold (10%, per Trello example)', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 5, voids: 2 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(10);
+    expect(tier!.effective_fold).toBe(5);
+  });
+
+  it('losers count toward effective fold', () => {
+    // 5 winners + 1 loser + 1 void → effective fold = 6 (winners+losers) → fold6 (12%)
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 5, losers: 1, voids: 1 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(12);
+    expect(tier!.effective_fold).toBe(6);
+  });
+
+  it('treats half_won/half_lost as graded legs', () => {
+    const arr: BoostLeg[] = [
+      { result: 'winner' },
+      { result: 'winner' },
+      { result: 'winner' },
+      { result: 'winner' },
+      { result: 'half_won' },
+      { result: 'half_lost' },
+      { result: 'void' },
+    ];
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: arr,
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.effective_fold).toBe(6);
+    expect(tier!.percentage).toBe(12);
+  });
+
+  it('below-table floor: 3 voids → effective 4-fold → applies lowest tier (fold5, 10%)', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ winners: 4, voids: 3 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(10);
+    expect(tier!.effective_fold).toBe(4);
+  });
+
+  it('no live tiers but has snapshot + voids → replays snapshot percentage', () => {
+    const tier = resolveAccaTier({
+      config: { ...sevenTierConfig, bet_types: [] },
+      bets: legs({ winners: 5, voids: 2 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(15);
+    expect(tier!.max_award).toBe(1000);
+  });
+
+  it('config disabled + voids → falls back to snapshot', () => {
+    const tier = resolveAccaTier({
+      config: { ...sevenTierConfig, enabled: false },
+      bets: legs({ winners: 5, voids: 2 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.percentage).toBe(15);
+  });
+
+  it('voids but no snapshot + no live tiers → null', () => {
+    const tier = resolveAccaTier({
+      config: { ...sevenTierConfig, bet_types: [] },
+      bets: legs({ winners: 5, voids: 2 }),
+      snapshot: null,
+    });
+    expect(tier).toBeNull();
+  });
+
+  it('all legs void → effective fold 0 → applies floor (lowest tier)', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: legs({ voids: 7 }),
+      snapshot: { percentage_boost: 15, max_award: 1000 },
+    });
+    expect(tier!.effective_fold).toBe(0);
+    expect(tier!.percentage).toBe(10); // floor
+  });
+
+  it('snapshot caps recompute (defensive): snapshot 8%, table tier 15% → 8%', () => {
+    const tier = resolveAccaTier({
+      config: sevenTierConfig,
+      bets: [
+        { result: 'winner' },
+        { result: 'winner' },
+        { result: 'winner' },
+        { result: 'winner' },
+        { result: 'winner' },
+        { result: 'winner' },
+        { result: 'void' },
+      ],
+      snapshot: { percentage_boost: 8, max_award: 1000 },
+    });
+    // Effective fold = 6 → live tier 12%, but snapshot caps at 8%.
+    expect(tier!.percentage).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary
Extracts the void-aware acca tier resolver from `swiftyPredictionsELBAPI` (auto-settle) and `SwiftyPredictionsCMSEB` (manual-settle), which both shipped near-identical copies as part of Trello [5063]. Future tier-rule changes touch one file, not two, and preview/persist parity is guaranteed by construction.

### Public API
- `resolveAccaTier({ config, bets, snapshot, placementBetType })` → `{ percentage, max_award, effective_fold } | null`
- `effectiveBetTypeKey(fold)` / `betTypeKeyToFold(key)`
- `hasAnyVoidLeg(bets)` / `countEffectiveFold(bets)`
- `parseRulesSnapshot(raw)` — generic, also useful for `bb_boost_rules` / `lucky_boost_rules`
- Interfaces: `AccaBoostConfig`, `AccaBoostTier`, `AccaRulesSnapshot`, `BoostLeg`, `AccaTierResolution`, `ResolveAccaTierParams`

### Out of scope
- DB-bound `getAccaBoostConfig()` stays in each consumer repo
- Orchestrators (`calculateSettlementBoost`, `applyManualBoost`, `calculateBoost`, `playbookResultMultiples`) stay in their owning repos and import the resolver

### Companion PRs (queued — to merge after this publishes)
- `swiftyPredictionsELBAPI` — `refactor/use-shared-acca-resolver` (opening after 1.0.124 publishes)
- `SwiftyPredictionsCMSEB` — `refactor/use-shared-acca-resolver` (opening after 1.0.124 publishes)

### Test plan
- [x] `npm test` — 50 suites, 545 passed, 0 failures (37 new tests for accaBoost.ts)
- [x] `npm run lint` — 0 errors / 0 new warnings on changed files
- [x] `npm run build` — emits `dist/BetCalculator/accaBoost.{js,d.ts}`
- [ ] Merge → `autoPublish.workflow.yml` publishes `@swiftyglobal/swifty-shared@1.0.124` to GitHub Packages
- [ ] Verify the new version is resolvable, then the consumer PRs can install it

🤖 Generated with [Claude Code](https://claude.com/claude-code)