### PR TITLE
feat(BetCalculator): extract BB / Lucky boost + odd-math + BoostType [round 2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.124",
+  "version": "1.0.125",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/BetCalculator/bbBoost.ts
+++ b/src/BetCalculator/bbBoost.ts
@@ -1,0 +1,88 @@
+/**
+ * Bet Builder boost calculator — shared by auto-settle (worker) and
+ * manual-settle (CMS). Pure function, no DB, no logging.
+ *
+ * Rules:
+ *   - Every leg must be a clean "winner". Any non-clean-winner result
+ *     (void / pushed / push / half_won / half_lost) disqualifies the boost,
+ *     because the bet's leg composition no longer matches what the player
+ *     placed.
+ *   - Snapshot wins over live config (the player gets the rule they were
+ *     promised at placement, even if the trader has since edited config).
+ *   - winnings = return_amount - stake; if winnings ≤ 0 → boost = 0.
+ *   - amount = winnings × (percentage / 100), capped by max_award, rounded
+ *     to cents.
+ *
+ * Returns 0 when not eligible. Callers wrap to their own response shape.
+ */
+
+import type { BoostLeg } from './accaBoost';
+import { parseRulesSnapshot } from './accaBoost';
+
+/** Single entry from `settings_v2.bet_builder_boost_selections`. */
+export interface BBBoostSelectionTier {
+  /** Number of selections this tier applies to, as a string ("2", "3", ...) — matches the DB JSON shape. */
+  selections: string;
+  percentage_boost: number | string;
+}
+
+/** Live BB boost config loaded from settings_v2. */
+export interface BBBoostConfig {
+  enabled: boolean;
+  selections: BBBoostSelectionTier[];
+  max_award?: number;
+}
+
+/** Placement-time snapshot stored on `users_bets.bb_boost_rules`. */
+export interface BBRulesSnapshot {
+  percentage_boost: number | string;
+  max_award?: number | string;
+  [key: string]: unknown;
+}
+
+export interface CalculateBBBoostParams {
+  /** Payout after BOG + Acca boost, before BB boost. */
+  return_amount: number;
+  /** Per-line stake (BB is single-line). */
+  stake: number;
+  /** Graded legs from user_bets_single. Every one must be a clean winner. */
+  resultedSingleBets: BoostLeg[];
+  /** Placement-time snapshot (preferred over live config). */
+  snapshot?: BBRulesSnapshot | string | null;
+  /** Live config fallback for legacy bets without a snapshot. */
+  config?: BBBoostConfig | null;
+}
+
+/**
+ * Returns the BB boost amount in cents-rounded units. 0 when not eligible.
+ */
+export function calculateBBBoost(params: CalculateBBBoostParams): number {
+  const { return_amount, stake, resultedSingleBets, config } = params;
+  const snapshot = parseRulesSnapshot<BBRulesSnapshot>(params.snapshot);
+
+  if (!Array.isArray(resultedSingleBets) || resultedSingleBets.length === 0) return 0;
+
+  const allCleanWinners = resultedSingleBets.every((leg) => String(leg?.result ?? '').toLowerCase() === 'winner');
+  if (!allCleanWinners) return 0;
+
+  const winnings = Number(return_amount) - Number(stake);
+  if (!(winnings > 0)) return 0;
+
+  let percentage = 0;
+  let cap = 0;
+  if (snapshot && Number(snapshot.percentage_boost) > 0) {
+    percentage = Number(snapshot.percentage_boost) / 100;
+    cap = Number(snapshot.max_award) || 0;
+  } else if (config && config.enabled) {
+    const match = (config.selections || []).find((s) => String(s.selections) === String(resultedSingleBets.length));
+    if (match) {
+      percentage = Number(match.percentage_boost) / 100;
+      cap = Number(config.max_award) || 0;
+    }
+  }
+  if (!(percentage > 0)) return 0;
+
+  let amount = winnings * percentage;
+  if (cap > 0 && amount > cap) amount = cap;
+  return Math.round(amount * 100) / 100;
+}

--- a/src/BetCalculator/index.ts
+++ b/src/BetCalculator/index.ts
@@ -1,3 +1,6 @@
 export * from './bet-calculator.class';
 export * from './bet-calculator.helper';
 export * from './accaBoost';
+export * from './bbBoost';
+export * from './luckyBoost';
+export * from './oddAdjustments';

--- a/src/BetCalculator/luckyBoost.ts
+++ b/src/BetCalculator/luckyBoost.ts
@@ -1,0 +1,213 @@
+/**
+ * Lucky Boost calculator — shared by auto-settle (worker) and manual-settle (CMS).
+ * Pure function, no DB, no logging.
+ *
+ * Lucky bets (lucky15 / lucky31 / lucky63) carry two independent bonus rules:
+ *
+ *   - **one_winner**  — consolation when exactly 1 selection wins; boosts the
+ *     winning single's odds via a "double" / "treble" / percentage multiplier.
+ *   - **all_winners** — full-win bonus when every selection wins; a percentage
+ *     of total winnings.
+ *
+ * Both branches are gated by:
+ *   - the eligible_sports allow-list (when supplied; undefined = no gate, []
+ *     = boost disabled),
+ *   - any void/pushed leg disqualifies (uniformly for all three bet types),
+ *   - a positive max_award cap (≤ 0 disables the boost entirely).
+ *
+ * Caller wraps the bare `{ amount, type }` result to its own response shape.
+ */
+
+import type { BoostLeg } from './accaBoost';
+import { oddAfterRule4 } from './oddAdjustments';
+
+/** Lucky bet types supported. Matches `BetSlipType.LUCKY_*` without the prefix. */
+export const LUCKY_BET_TYPES = ['lucky15', 'lucky31', 'lucky63'] as const;
+export type LuckyBetType = (typeof LUCKY_BET_TYPES)[number];
+
+/** Number of single selections per Lucky bet type (lucky15 = 4 picks, etc.). */
+export const LUCKY_TOTAL_SELECTIONS: Record<LuckyBetType, number> = {
+  lucky15: 4,
+  lucky31: 5,
+  lucky63: 6,
+};
+
+/** Total winning lines per Lucky bet type (used to derive total stake). */
+export const LUCKY_TOTAL_LINES: Record<LuckyBetType, number> = {
+  lucky15: 15,
+  lucky31: 31,
+  lucky63: 63,
+};
+
+/** Per-bet-type rule shape stored at placement and replayed at settle. */
+export interface LuckyPerTypeConfig {
+  one_winner?: string | number | null;
+  all_winners?: string | number | null;
+  eligible_sports?: string[];
+  max_award?: number;
+  [key: string]: unknown;
+}
+
+/** Full live Lucky config from settings_v2.lucky_boost_config. */
+export interface LuckyBoostConfig {
+  enabled: boolean;
+  config: Partial<Record<LuckyBetType, LuckyPerTypeConfig>> & {
+    eligible_sports?: string[];
+    max_award?: number;
+  };
+}
+
+/** Strip `bet_slip_place_` if present and return the lucky bet-type slug. */
+export function cleanLuckyBetType(input: string | null | undefined): string {
+  if (input == null) return '';
+  return String(input).replace('bet_slip_place_', '');
+}
+
+/** Return true iff `bet_type` (after stripping prefix) is a Lucky bet type. */
+export function isLuckyBetType(input: string | null | undefined): input is LuckyBetType {
+  const clean = cleanLuckyBetType(input);
+  return (LUCKY_BET_TYPES as readonly string[]).includes(clean);
+}
+
+/**
+ * Parse a Lucky boost value from CMS dropdown / settings JSON.
+ *
+ * Accepts: "double" | "treble" | "none" | "" | numeric (e.g. "5", "5%", 5).
+ * Returns a discriminated union for safe handling.
+ */
+export type ParsedBoostValue =
+  | { kind: 'none' }
+  | { kind: 'double' }
+  | { kind: 'treble' }
+  | { kind: 'percent'; percent: number };
+
+export function parseBoostValue(raw: unknown): ParsedBoostValue {
+  if (raw === undefined || raw === null) return { kind: 'none' };
+  const v = String(raw).trim().toLowerCase();
+  if (!v || v === 'none') return { kind: 'none' };
+  if (v === 'double') return { kind: 'double' };
+  if (v === 'treble') return { kind: 'treble' };
+  const num = parseFloat(v.replace('%', ''));
+  if (!isNaN(num) && num > 0) return { kind: 'percent', percent: num };
+  return { kind: 'none' };
+}
+
+/** Result of the Lucky boost calculation. */
+export type LuckyBoostResult =
+  | {
+      amount: number;
+      type: 'one_winner' | 'all_winners';
+      /** The parsed value that drove the calculation — useful for label-building. */
+      applied: ParsedBoostValue;
+    }
+  | { amount: 0; type: null; applied: null };
+
+export interface CalculateLuckyBoostParams {
+  /** Full Lucky config (placement snapshot wrapped, or live config). */
+  config: LuckyBoostConfig | null | undefined;
+  /** Lucky bet_type — accepts either `lucky15` or `bet_slip_place_lucky15`. */
+  bet_type: string;
+  /** Stake per line (NOT total stake). Total stake is derived via LUCKY_TOTAL_LINES. */
+  stake_per_line: number;
+  /** Total payout for the bet (sum of all winning lines), used by the all-winners branch. */
+  return_amount: number;
+  /** All Lucky single legs with `result` + `sport_slug` + `odd` (+ optional `rule_4`). */
+  resultedSingleBets: BoostLeg[];
+  /** Allow-list of sport slugs. Pass `undefined` to skip the gate; `[]` to disable boost. */
+  eligible_sports?: string[];
+  /** Single global cap. Pass `≤ 0` to disable the boost entirely. */
+  max_award: number;
+}
+
+const EMPTY: LuckyBoostResult = { amount: 0, type: null, applied: null };
+
+/**
+ * Calculate Lucky boost amount + winning branch.
+ *
+ * Returns the bare numerics; callers wrap to their own response shape
+ * (worker uses `{ amount, type }`, CMS wraps to
+ * `{ boost_type, boost_percentage, boost_amount, boost_label }`).
+ */
+export function calculateLuckyBoost(params: CalculateLuckyBoostParams): LuckyBoostResult {
+  const { config, resultedSingleBets, eligible_sports } = params;
+
+  if (!config || !config.enabled) return EMPTY;
+  if (!isLuckyBetType(params.bet_type)) return EMPTY;
+  const clean = cleanLuckyBetType(params.bet_type) as LuckyBetType;
+
+  // Void/pushed disqualifies the boost uniformly across lucky15/31/63.
+  const legs = resultedSingleBets || [];
+  const voids = legs.filter((b) => {
+    const r = String(b?.result ?? '').toLowerCase();
+    return r === 'void' || r === 'pushed' || r === 'push';
+  }).length;
+  if (voids > 0) return EMPTY;
+
+  // eligible_sports gate (placement snapshot authoritative when supplied).
+  // `undefined` → no gate. `[]` → disabled. Otherwise every leg's sport_slug
+  // must be in the allow-list.
+  if (Array.isArray(eligible_sports)) {
+    const allowed = new Set(eligible_sports);
+    for (const leg of legs) {
+      const sport = (leg as { sport_slug?: string }).sport_slug;
+      if (!allowed.has(sport ?? '')) return EMPTY;
+    }
+  }
+
+  const perType = config.config?.[clean];
+  if (!perType) return EMPTY;
+
+  const totalSelections = LUCKY_TOTAL_SELECTIONS[clean];
+  const totalLines = LUCKY_TOTAL_LINES[clean];
+  const stake = Number(params.stake_per_line) || 0;
+
+  // Single global cap across both branches. max_award ≤ 0 disables the boost.
+  const cap = Number(params.max_award) || 0;
+  if (cap <= 0) return EMPTY;
+
+  const winners = legs.filter((b) => String(b?.result ?? '').toLowerCase() === 'winner').length;
+
+  // ALL WINNERS: percentage of winnings on total return.
+  if (winners === totalSelections) {
+    const parsed = parseBoostValue(perType.all_winners);
+    if (parsed.kind !== 'percent') return EMPTY;
+    const totalStake = stake * totalLines;
+    const winnings = Number(params.return_amount) - totalStake;
+    if (winnings <= 0) return EMPTY;
+    let amount = winnings * (parsed.percent / 100);
+    if (amount <= 0) return EMPTY;
+    if (amount > cap) amount = cap;
+    return { amount, type: 'all_winners', applied: parsed };
+  }
+
+  // ONE WINNER (consolation): boost the winning single's R4-adjusted odds.
+  if (winners === 1) {
+    const parsed = parseBoostValue(perType.one_winner);
+    if (parsed.kind === 'none') return EMPTY;
+
+    const winningSingle = legs.find((leg) => String(leg?.result ?? '').toLowerCase() === 'winner') as
+      | undefined
+      | { odd?: number | string; odd_decimal?: number | string; rule_4?: number | string };
+    if (!winningSingle) return EMPTY;
+
+    const rawOdd = Number(winningSingle.odd_decimal ?? winningSingle.odd ?? 0);
+    const odd = oddAfterRule4({ odd: rawOdd, rule4_percentage: winningSingle.rule_4 });
+    if (odd <= 0 || stake <= 0) return EMPTY;
+
+    // Bonus is a multiplier on the winnings portion only (stake always returned):
+    //   double  → bonus = (odd - 1) × stake
+    //   treble  → bonus = 2 × (odd - 1) × stake
+    //   percent → bonus = (odd - 1) × stake × X/100
+    const winningsPerLine = (odd - 1) * stake;
+    let amount = 0;
+    if (parsed.kind === 'double') amount = winningsPerLine;
+    else if (parsed.kind === 'treble') amount = 2 * winningsPerLine;
+    else if (parsed.kind === 'percent') amount = winningsPerLine * (parsed.percent / 100);
+
+    if (amount <= 0) return EMPTY;
+    if (amount > cap) amount = cap;
+    return { amount, type: 'one_winner', applied: parsed };
+  }
+
+  return EMPTY;
+}

--- a/src/BetCalculator/luckyBoost.ts
+++ b/src/BetCalculator/luckyBoost.ts
@@ -165,7 +165,13 @@ export function calculateLuckyBoost(params: CalculateLuckyBoostParams): LuckyBoo
   const cap = Number(params.max_award) || 0;
   if (cap <= 0) return EMPTY;
 
-  const winners = legs.filter((b) => String(b?.result ?? '').toLowerCase() === 'winner').length;
+  // Worker counts half_won / half_lost as winners for the consolation/all-win
+  // gates (Lucky bets shouldn't actually carry EW partials, but the count is
+  // pre-computed in the worker as winner + half_won + half_lost so we mirror).
+  const winners = legs.filter((b) => {
+    const r = String(b?.result ?? '').toLowerCase();
+    return r === 'winner' || r === 'half_won' || r === 'half_lost';
+  }).length;
 
   // ALL WINNERS: percentage of winnings on total return.
   if (winners === totalSelections) {

--- a/src/BetCalculator/oddAdjustments.ts
+++ b/src/BetCalculator/oddAdjustments.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure odd-math helpers shared by the auto-settle worker
+ * (swiftyPredictionsELBAPI) and the manual-settle CMS (SwiftyPredictionsCMSEB).
+ *
+ * No DB, no logging, no side-effects.
+ */
+
+/**
+ * Apply Rule 4 (non-runner deduction) to a decimal odd.
+ *
+ * Formula: `odd' = 1 + (odd - 1) × (1 - r4/100)`
+ *
+ * - Returns 0 when the input odd is non-positive.
+ * - Returns the original odd unchanged when r4 ≤ 0 (no deduction).
+ * - r4 is the deduction percentage as a number (e.g. `25` for 25%).
+ */
+export function oddAfterRule4(params: {
+  odd: number | string;
+  rule4_percentage: number | string | null | undefined;
+}): number {
+  const numOdd = Number(params.odd) || 0;
+  const r4 = Number(params.rule4_percentage) || 0;
+  if (numOdd <= 0) return 0;
+  if (r4 <= 0) return numOdd;
+  return 1 + (numOdd - 1) * (1 - r4 / 100);
+}
+
+/**
+ * Resolve the starting-price odd to use for settlement, honouring an explicit
+ * provider-supplied SP+R4 value when present.
+ *
+ * Some providers (BetRadar / SIS) deliver the SP-after-R4 directly via
+ * `rule4_bog_odd`; when that's non-zero we use it as-is (it already encodes
+ * the deduction). Otherwise we apply Rule 4 to the raw SP ourselves.
+ */
+export function spOddAfterRule4(params: {
+  starting_price_odd: number | string;
+  rule4_percentage: number | string | null | undefined;
+  rule4_bog_odd?: number | string | null | undefined;
+}): number {
+  const rule4BogOdd = Number(params.rule4_bog_odd) || 0;
+  if (rule4BogOdd > 0) return rule4BogOdd;
+  return oddAfterRule4({
+    odd: params.starting_price_odd,
+    rule4_percentage: params.rule4_percentage,
+  });
+}

--- a/src/common/constants/boostType.ts
+++ b/src/common/constants/boostType.ts
@@ -1,0 +1,15 @@
+/**
+ * Boost tag identifiers used on `users_bets.tags` (comma-separated string).
+ * Tag presence is the placement-time gate: a bet must carry the matching tag
+ * to be eligible for that boost at settlement, regardless of the player's
+ * current bet_enhancements_enabled flag.
+ *
+ * Single source of truth so the worker (auto-settle) and CMS (manual-settle)
+ * never drift on string literals.
+ */
+export enum BoostType {
+  ACCA = 'ACCA_BOOST',
+  BB = 'BB_BOOST',
+  LUCKY = 'LUCKY_BOOST',
+  BOG = 'BOG',
+}

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -21,3 +21,4 @@ export * from './countryCodes';
 export * from './currencies';
 export * from './errorCodes';
 export * from './transactions';
+export * from './boostType';

--- a/src/tests/BetCalculator/bbBoost.test.ts
+++ b/src/tests/BetCalculator/bbBoost.test.ts
@@ -1,0 +1,133 @@
+import type { BBBoostConfig } from '../../BetCalculator/bbBoost';
+import { calculateBBBoost } from '../../BetCalculator/bbBoost';
+import type { BoostLeg } from '../../BetCalculator/accaBoost';
+
+function winners(n: number): BoostLeg[] {
+  return Array.from({ length: n }, () => ({ result: 'winner' }));
+}
+
+const liveConfig: BBBoostConfig = {
+  enabled: true,
+  max_award: 100,
+  selections: [
+    { selections: '2', percentage_boost: 5 },
+    { selections: '3', percentage_boost: 10 },
+    { selections: '4', percentage_boost: 15 },
+  ],
+};
+
+describe('calculateBBBoost', () => {
+  it('returns 0 when no legs', () => {
+    expect(calculateBBBoost({ return_amount: 100, stake: 10, resultedSingleBets: [], config: liveConfig })).toBe(0);
+  });
+
+  it('returns 0 if any leg is not a clean winner', () => {
+    const legs: BoostLeg[] = [{ result: 'winner' }, { result: 'void' }];
+    expect(calculateBBBoost({ return_amount: 100, stake: 10, resultedSingleBets: legs, config: liveConfig })).toBe(0);
+
+    const legs2: BoostLeg[] = [{ result: 'winner' }, { result: 'half_won' }];
+    expect(calculateBBBoost({ return_amount: 100, stake: 10, resultedSingleBets: legs2, config: liveConfig })).toBe(0);
+
+    const legs3: BoostLeg[] = [{ result: 'winner' }, { result: 'pushed' }];
+    expect(calculateBBBoost({ return_amount: 100, stake: 10, resultedSingleBets: legs3, config: liveConfig })).toBe(0);
+  });
+
+  it('returns 0 when winnings ≤ 0', () => {
+    expect(calculateBBBoost({ return_amount: 10, stake: 10, resultedSingleBets: winners(2), config: liveConfig })).toBe(
+      0,
+    );
+  });
+
+  it('uses snapshot percentage when present (preferred over live)', () => {
+    // snapshot 7% wins over live tier (5% for 2 selections).
+    const result = calculateBBBoost({
+      return_amount: 110,
+      stake: 10,
+      resultedSingleBets: winners(2),
+      snapshot: { percentage_boost: 7, max_award: 100 },
+      config: liveConfig,
+    });
+    // winnings = 100, 7% = 7.00
+    expect(result).toBeCloseTo(7.0, 4);
+  });
+
+  it('parses snapshot if passed as JSON string', () => {
+    const result = calculateBBBoost({
+      return_amount: 110,
+      stake: 10,
+      resultedSingleBets: winners(2),
+      snapshot: JSON.stringify({ percentage_boost: 7, max_award: 100 }),
+      config: liveConfig,
+    });
+    expect(result).toBeCloseTo(7.0, 4);
+  });
+
+  it('falls back to live config matched by selections count', () => {
+    const result = calculateBBBoost({
+      return_amount: 110,
+      stake: 10,
+      resultedSingleBets: winners(3),
+      snapshot: null,
+      config: liveConfig,
+    });
+    // 3 selections → 10% of 100 = 10
+    expect(result).toBeCloseTo(10.0, 4);
+  });
+
+  it('caps at snapshot max_award', () => {
+    const result = calculateBBBoost({
+      return_amount: 1000,
+      stake: 10,
+      resultedSingleBets: winners(2),
+      snapshot: { percentage_boost: 50, max_award: 5 },
+    });
+    // raw boost would be 495, capped at 5.
+    expect(result).toBe(5);
+  });
+
+  it('caps at live config max_award when no snapshot', () => {
+    const result = calculateBBBoost({
+      return_amount: 1000,
+      stake: 10,
+      resultedSingleBets: winners(2),
+      snapshot: null,
+      config: { ...liveConfig, max_award: 3 },
+    });
+    expect(result).toBe(3);
+  });
+
+  it('no boost when neither snapshot nor matching live tier', () => {
+    expect(
+      calculateBBBoost({
+        return_amount: 100,
+        stake: 10,
+        resultedSingleBets: winners(7), // no tier for 7
+        snapshot: null,
+        config: liveConfig,
+      }),
+    ).toBe(0);
+  });
+
+  it('config disabled → 0', () => {
+    expect(
+      calculateBBBoost({
+        return_amount: 100,
+        stake: 10,
+        resultedSingleBets: winners(2),
+        snapshot: null,
+        config: { ...liveConfig, enabled: false },
+      }),
+    ).toBe(0);
+  });
+
+  it('rounds to cents', () => {
+    const result = calculateBBBoost({
+      return_amount: 33.33,
+      stake: 10,
+      resultedSingleBets: winners(2),
+      snapshot: { percentage_boost: 7 },
+    });
+    // winnings = 23.33, 7% = 1.6331 → rounded to 1.63
+    expect(result).toBe(1.63);
+  });
+});

--- a/src/tests/BetCalculator/luckyBoost.test.ts
+++ b/src/tests/BetCalculator/luckyBoost.test.ts
@@ -1,0 +1,376 @@
+import type { LuckyBoostConfig } from '../../BetCalculator/luckyBoost';
+import {
+  calculateLuckyBoost,
+  parseBoostValue,
+  isLuckyBetType,
+  cleanLuckyBetType,
+  LUCKY_TOTAL_LINES,
+  LUCKY_TOTAL_SELECTIONS,
+} from '../../BetCalculator/luckyBoost';
+import type { BoostLeg } from '../../BetCalculator/accaBoost';
+
+describe('parseBoostValue', () => {
+  it("'double' / 'treble'", () => {
+    expect(parseBoostValue('double')).toEqual({ kind: 'double' });
+    expect(parseBoostValue('treble')).toEqual({ kind: 'treble' });
+    expect(parseBoostValue('Double')).toEqual({ kind: 'double' }); // case-insensitive
+  });
+  it('percent forms', () => {
+    expect(parseBoostValue('5')).toEqual({ kind: 'percent', percent: 5 });
+    expect(parseBoostValue('5%')).toEqual({ kind: 'percent', percent: 5 });
+    expect(parseBoostValue(5)).toEqual({ kind: 'percent', percent: 5 });
+    expect(parseBoostValue('5.5%')).toEqual({ kind: 'percent', percent: 5.5 });
+  });
+  it('none / empty / null', () => {
+    expect(parseBoostValue('none')).toEqual({ kind: 'none' });
+    expect(parseBoostValue('')).toEqual({ kind: 'none' });
+    expect(parseBoostValue(null)).toEqual({ kind: 'none' });
+    expect(parseBoostValue(undefined)).toEqual({ kind: 'none' });
+    expect(parseBoostValue('0')).toEqual({ kind: 'none' });
+    expect(parseBoostValue('abc')).toEqual({ kind: 'none' });
+  });
+});
+
+describe('isLuckyBetType / cleanLuckyBetType', () => {
+  it('accepts both prefixed and unprefixed slugs', () => {
+    expect(isLuckyBetType('lucky15')).toBe(true);
+    expect(isLuckyBetType('lucky31')).toBe(true);
+    expect(isLuckyBetType('lucky63')).toBe(true);
+    expect(isLuckyBetType('bet_slip_place_lucky15')).toBe(true);
+    expect(isLuckyBetType('bet_slip_place_lucky63')).toBe(true);
+  });
+  it('rejects others', () => {
+    expect(isLuckyBetType('fold5')).toBe(false);
+    expect(isLuckyBetType('double')).toBe(false);
+    expect(isLuckyBetType('')).toBe(false);
+    expect(isLuckyBetType(null)).toBe(false);
+  });
+  it('cleanLuckyBetType strips prefix', () => {
+    expect(cleanLuckyBetType('bet_slip_place_lucky15')).toBe('lucky15');
+    expect(cleanLuckyBetType('lucky15')).toBe('lucky15');
+    expect(cleanLuckyBetType(null)).toBe('');
+  });
+});
+
+describe('LUCKY_* maps', () => {
+  it('total lines and selections', () => {
+    expect(LUCKY_TOTAL_LINES).toEqual({ lucky15: 15, lucky31: 31, lucky63: 63 });
+    expect(LUCKY_TOTAL_SELECTIONS).toEqual({ lucky15: 4, lucky31: 5, lucky63: 6 });
+  });
+});
+
+const baseLuckyConfig = (): LuckyBoostConfig => ({
+  enabled: true,
+  config: {
+    lucky15: {
+      one_winner: 'double',
+      all_winners: '5',
+      eligible_sports: ['horseracing', 'greyhoundracing'],
+    },
+  },
+});
+
+function legs(
+  arr: Array<Partial<BoostLeg> & { result: string; odd?: number; sport_slug?: string; rule_4?: number }>,
+): BoostLeg[] {
+  return arr.map((l) => ({ sport_slug: 'horseracing', ...l }));
+}
+
+describe('calculateLuckyBoost — basic gates', () => {
+  it('returns empty when config disabled', () => {
+    const r = calculateLuckyBoost({
+      config: { ...baseLuckyConfig(), enabled: false },
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      eligible_sports: undefined,
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+    expect(r.type).toBeNull();
+  });
+
+  it('returns empty for non-lucky bet_type', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'fold5',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner' })),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('void leg disqualifies', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 2 },
+        { result: 'winner', odd: 2 },
+        { result: 'winner', odd: 2 },
+        { result: 'void', odd: 1 },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('explicit empty eligible_sports disables boost', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      eligible_sports: [], // disabled
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('sport_slug not in eligible_sports → disqualified', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2, sport_slug: 'football' })),
+      eligible_sports: ['horseracing'],
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('undefined eligible_sports → no gate (legacy path)', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 70,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2, sport_slug: 'football' })),
+      eligible_sports: undefined,
+      max_award: 100,
+    });
+    // 4 winners + lucky15 → all_winners 5% branch. totalStake = 1×15 = 15;
+    // winnings = 70 - 15 = 55; 5% = 2.75.
+    expect(r.type).toBe('all_winners');
+    expect(r.amount).toBeCloseTo(2.75, 4);
+  });
+
+  it('max_award ≤ 0 disables', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 100,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      max_award: 0,
+    });
+    expect(r.amount).toBe(0);
+  });
+});
+
+describe('calculateLuckyBoost — all-winners branch', () => {
+  it('lucky15 all win @ 5% all_winners', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 70,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      max_award: 100,
+    });
+    expect(r.type).toBe('all_winners');
+    // winnings = 70 - 15 = 55 → 5% = 2.75
+    expect(r.amount).toBeCloseTo(2.75, 4);
+  });
+
+  it('accepts bet_slip_place_ prefix', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'bet_slip_place_lucky15',
+      stake_per_line: 1,
+      return_amount: 70,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      max_award: 100,
+    });
+    expect(r.amount).toBeCloseTo(2.75, 4);
+  });
+
+  it('all_winners = "none" → no bonus even if all win', () => {
+    const cfg = baseLuckyConfig();
+    cfg.config.lucky15!.all_winners = 'none';
+    const r = calculateLuckyBoost({
+      config: cfg,
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 70,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('caps at max_award', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 10,
+      return_amount: 10000,
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 5 })),
+      max_award: 50,
+    });
+    expect(r.amount).toBe(50);
+  });
+
+  it('winnings ≤ 0 → no boost', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 15, // stake equals payout
+      resultedSingleBets: legs(Array(4).fill({ result: 'winner', odd: 2 })),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+});
+
+describe('calculateLuckyBoost — one-winner branch', () => {
+  it('double on £5 @ 3.00 → bonus £10', () => {
+    // (3 - 1) × 5 = 10
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 5,
+      return_amount: 15,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 3 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.type).toBe('one_winner');
+    expect(r.amount).toBeCloseTo(10, 4);
+  });
+
+  it('treble on £5 @ 3.00 → bonus £20', () => {
+    const cfg = baseLuckyConfig();
+    cfg.config.lucky15!.one_winner = 'treble';
+    const r = calculateLuckyBoost({
+      config: cfg,
+      bet_type: 'lucky15',
+      stake_per_line: 5,
+      return_amount: 15,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 3 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBeCloseTo(20, 4);
+  });
+
+  it('percent (10%) on £5 @ 3.00 → bonus £1', () => {
+    const cfg = baseLuckyConfig();
+    cfg.config.lucky15!.one_winner = '10%';
+    const r = calculateLuckyBoost({
+      config: cfg,
+      bet_type: 'lucky15',
+      stake_per_line: 5,
+      return_amount: 15,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 3 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBeCloseTo(1, 4);
+  });
+
+  it('R4-adjusts the odd before computing bonus', () => {
+    // odd 3.0 with R4 50% → adjusted = 1 + (3-1) × 0.5 = 2.0
+    // double on stake 5: (2 - 1) × 5 = 5
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 5,
+      return_amount: 10,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 3, rule_4: 50 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBeCloseTo(5, 4);
+  });
+
+  it('one_winner = "none" → no bonus', () => {
+    const cfg = baseLuckyConfig();
+    cfg.config.lucky15!.one_winner = 'none';
+    const r = calculateLuckyBoost({
+      config: cfg,
+      bet_type: 'lucky15',
+      stake_per_line: 5,
+      return_amount: 15,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 3 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+
+  it('caps one-winner at max_award', () => {
+    // (10 - 1) × 100 = 900 → capped at 50
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 100,
+      return_amount: 1000,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 10 },
+        { result: 'loser' },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 50,
+    });
+    expect(r.amount).toBe(50);
+  });
+});
+
+describe('calculateLuckyBoost — neither branch fires', () => {
+  it('2 winners + 2 losers → no consolation, no all-win', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 5,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 2 },
+        { result: 'winner', odd: 2 },
+        { result: 'loser' },
+        { result: 'loser' },
+      ]),
+      max_award: 100,
+    });
+    expect(r.amount).toBe(0);
+  });
+});

--- a/src/tests/BetCalculator/luckyBoost.test.ts
+++ b/src/tests/BetCalculator/luckyBoost.test.ts
@@ -356,6 +356,25 @@ describe('calculateLuckyBoost — one-winner branch', () => {
   });
 });
 
+describe('calculateLuckyBoost — half_won/half_lost count as winners (worker parity)', () => {
+  it('3 winners + 1 half_won → counts as 4 winners → all-winners branch fires', () => {
+    const r = calculateLuckyBoost({
+      config: baseLuckyConfig(),
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 70,
+      resultedSingleBets: legs([
+        { result: 'winner', odd: 2 },
+        { result: 'winner', odd: 2 },
+        { result: 'winner', odd: 2 },
+        { result: 'half_won', odd: 2 },
+      ]),
+      max_award: 100,
+    });
+    expect(r.type).toBe('all_winners');
+  });
+});
+
 describe('calculateLuckyBoost — neither branch fires', () => {
   it('2 winners + 2 losers → no consolation, no all-win', () => {
     const r = calculateLuckyBoost({

--- a/src/tests/BetCalculator/oddAdjustments.test.ts
+++ b/src/tests/BetCalculator/oddAdjustments.test.ts
@@ -1,0 +1,39 @@
+import { oddAfterRule4, spOddAfterRule4 } from '../../BetCalculator/oddAdjustments';
+
+describe('oddAfterRule4', () => {
+  it('returns 0 for non-positive odd', () => {
+    expect(oddAfterRule4({ odd: 0, rule4_percentage: 25 })).toBe(0);
+    expect(oddAfterRule4({ odd: -1, rule4_percentage: 25 })).toBe(0);
+    expect(oddAfterRule4({ odd: '0', rule4_percentage: 25 })).toBe(0);
+  });
+
+  it('returns odd unchanged when r4 ≤ 0', () => {
+    expect(oddAfterRule4({ odd: 3.5, rule4_percentage: 0 })).toBe(3.5);
+    expect(oddAfterRule4({ odd: 3.5, rule4_percentage: null })).toBe(3.5);
+    expect(oddAfterRule4({ odd: 3.5, rule4_percentage: undefined })).toBe(3.5);
+    expect(oddAfterRule4({ odd: 3.5, rule4_percentage: -10 })).toBe(3.5);
+  });
+
+  it('applies the canonical formula', () => {
+    // 1 + (3 - 1) × (1 - 25/100) = 1 + 2 × 0.75 = 2.5
+    expect(oddAfterRule4({ odd: 3, rule4_percentage: 25 })).toBe(2.5);
+    // 1 + (5 - 1) × (1 - 50/100) = 1 + 4 × 0.5 = 3
+    expect(oddAfterRule4({ odd: 5, rule4_percentage: 50 })).toBe(3);
+  });
+
+  it('handles string inputs', () => {
+    expect(oddAfterRule4({ odd: '3', rule4_percentage: '25' })).toBe(2.5);
+  });
+});
+
+describe('spOddAfterRule4', () => {
+  it('uses rule4_bog_odd when supplied (non-zero)', () => {
+    // rule4_bog_odd wins regardless of starting_price_odd / rule4_percentage.
+    expect(spOddAfterRule4({ starting_price_odd: 5, rule4_percentage: 50, rule4_bog_odd: 2.4 })).toBe(2.4);
+  });
+
+  it('falls through to oddAfterRule4 when rule4_bog_odd is 0 / missing', () => {
+    expect(spOddAfterRule4({ starting_price_odd: 3, rule4_percentage: 25, rule4_bog_odd: 0 })).toBe(2.5);
+    expect(spOddAfterRule4({ starting_price_odd: 3, rule4_percentage: 25 })).toBe(2.5);
+  });
+});

--- a/src/tests/common/boostType.test.ts
+++ b/src/tests/common/boostType.test.ts
@@ -1,0 +1,10 @@
+import { BoostType } from '../../common/constants/boostType';
+
+describe('BoostType', () => {
+  it('exposes the canonical tag strings', () => {
+    expect(BoostType.ACCA).toBe('ACCA_BOOST');
+    expect(BoostType.BB).toBe('BB_BOOST');
+    expect(BoostType.LUCKY).toBe('LUCKY_BOOST');
+    expect(BoostType.BOG).toBe('BOG');
+  });
+});


### PR DESCRIPTION
## Summary
Second wave of consolidation between `swiftyPredictionsELBAPI` and `SwiftyPredictionsCMSEB`. Four new shared modules so the two repos stop maintaining parallel boost implementations.

### Public API additions
- `calculateBBBoost({ return_amount, stake, resultedSingleBets, snapshot?, config? })` → `number` (0 when ineligible). All-clean-winners gate + snapshot-vs-live-config precedence.
- `calculateLuckyBoost({ config, bet_type, stake_per_line, return_amount, resultedSingleBets, eligible_sports?, max_award })` → `{ amount, type, applied }`. Both one-winner consolation and all-winners full-win branches.
- `parseBoostValue(raw)` → `{ kind: 'double' | 'treble' | 'percent' | 'none', percent? }`.
- `isLuckyBetType(s)`, `cleanLuckyBetType(s)`, `LUCKY_BET_TYPES`, `LUCKY_TOTAL_LINES`, `LUCKY_TOTAL_SELECTIONS`.
- `oddAfterRule4({ odd, rule4_percentage })`, `spOddAfterRule4({ starting_price_odd, rule4_percentage, rule4_bog_odd? })`.
- `BoostType` enum (`ACCA_BOOST` / `BB_BOOST` / `LUCKY_BOOST` / `BOG`).

All four modules are pure (no DB, no logging, no env coupling).

### Base branch
This PR targets **`feat/acca-boost-resolver`** (round 1) so the two PRs ship together. Once round 1 is approved-and-merged into `master`, retarget this one to `master` and merge — autoPublish will publish `@swiftyglobal/swifty-shared@1.0.125`.

### Test plan
- [x] `npm test` — 54 suites, **589 passed**, 0 failures (44 new unit tests; 81 total for the BetCalculator boost helpers)
- [x] `npm run lint` — 0 errors / 0 warnings on changed files
- [x] `npm run build` — emits `dist/BetCalculator/{bbBoost,luckyBoost,oddAdjustments}.{js,d.ts}` and `dist/common/constants/boostType.{js,d.ts}`
- [ ] Merge round 1 first → 1.0.124 publishes
- [ ] Retarget this PR to `master` → merge → autoPublish publishes 1.0.125
- [ ] Consumer PRs (worker + CMS) pin `^1.0.125` and pick up the new helpers

### Companion PRs (queued)
- Round 1 swiftyShared: https://github.com/SwiftyGlobal/swiftyShared/pull/157
- Worker: https://github.com/SwiftyGlobal/swiftyPredictionsELBAPI/pull/4260 (will be updated to use the new helpers)
- CMS: https://github.com/SwiftyGlobal/SwiftyPredictionsCMSEB/pull/8540 (same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)