### PR TITLE
feat(common): add WinningCombo DTO, cast validators, shared race enums

### DIFF
--- a/src/common/constants/castResultType.ts
+++ b/src/common/constants/castResultType.ts
@@ -1,0 +1,8 @@
+export enum CastResultType {
+  NOT_APPLICABLE = 'not_applicable',
+  HIT = 'hit',
+  MISSED = 'missed',
+  VOID = 'void',
+  SINGLE = 'single',
+  FORECAST = 'forecast',
+}

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -22,3 +22,5 @@ export * from './currencies';
 export * from './errorCodes';
 export * from './transactions';
 export * from './boostType';
+export * from './raceSelectionStatus';
+export * from './castResultType';

--- a/src/common/constants/raceSelectionStatus.ts
+++ b/src/common/constants/raceSelectionStatus.ts
@@ -1,0 +1,28 @@
+import { BetResultType } from './betResultType';
+
+export enum RaceSelectionStatus {
+  RUNNER = 'Runner',
+  NON_RUNNER = 'NonRunner',
+  PULLED_UP = 'PulledUp',
+  WINNER = 'Winner',
+  PLACED = 'Placed',
+  LOSER = 'Loser',
+  NON_AVAILABLE = 'NonAvailable',
+}
+
+export const raceSelectionMap = (race_status: RaceSelectionStatus | string): BetResultType => {
+  switch (race_status) {
+    case RaceSelectionStatus.NON_RUNNER:
+    case RaceSelectionStatus.PULLED_UP:
+      return BetResultType.VOID;
+    case RaceSelectionStatus.WINNER:
+      return BetResultType.WINNER;
+    case RaceSelectionStatus.PLACED:
+      return BetResultType.PLACED;
+    case RaceSelectionStatus.LOSER:
+      return BetResultType.LOSER;
+    case RaceSelectionStatus.NON_AVAILABLE:
+    default:
+      return BetResultType.OPEN;
+  }
+};

--- a/src/common/dto/CastSettlement.ts
+++ b/src/common/dto/CastSettlement.ts
@@ -1,0 +1,13 @@
+/**
+ * One winning combination for a tote-style cast bet (forecast / tricast).
+ * On a dead heat a race produces multiple WinningCombo entries with different
+ * selectionIds and different dividends — settlement must pay each matching combo.
+ *
+ * selectionIds is provider-ordered (1st-place runner first, then 2nd, then 3rd
+ * for tricast). Length is 2 for forecast/exacta, 3 for tricast/trifecta.
+ * dividend is FX-converted to the bet's currency at the point of resolution.
+ */
+export interface WinningCombo {
+  selectionIds: string[];
+  dividend: number;
+}

--- a/src/common/dto/index.ts
+++ b/src/common/dto/index.ts
@@ -2,3 +2,4 @@ export * from './getLadderBoostedPrice.v2.dto';
 export * from './events';
 export * from './betOdd';
 export * from './PlacedBet';
+export * from './CastSettlement';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './validator/ajvValidator';
+export * from './validator/castValidator';
 export * from './dto';

--- a/src/common/validator/castValidator.ts
+++ b/src/common/validator/castValidator.ts
@@ -1,0 +1,61 @@
+import { ValidateFunction } from 'ajv';
+
+import { AjvValidator } from './ajvValidator';
+
+const ajv = AjvValidator.getInstance();
+
+const buildSchema = (selectionLength: number) => ({
+  type: 'array',
+  minItems: 1,
+  items: {
+    type: 'object',
+    required: ['selectionIds', 'dividend'],
+    additionalProperties: false,
+    properties: {
+      selectionIds: {
+        type: 'array',
+        minItems: selectionLength,
+        maxItems: selectionLength,
+        items: { type: 'string', minLength: 1 },
+      },
+      dividend: { type: 'number', exclusiveMinimum: 0 },
+    },
+  },
+});
+
+const forecastCombosValidator: ValidateFunction = ajv.compile(buildSchema(2));
+const tricastCombosValidator: ValidateFunction = ajv.compile(buildSchema(3));
+
+const hasDuplicateRows = (combos: Array<{ selectionIds: string[] }>): boolean => {
+  const seen = new Set<string>();
+  for (const combo of combos) {
+    const key = JSON.stringify(combo.selectionIds);
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
+};
+
+export interface CastValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const runValidator = (validator: ValidateFunction, data: unknown, label: string): CastValidationResult => {
+  if (!validator(data)) {
+    return {
+      valid: false,
+      errors: (validator.errors ?? []).map((e) => `${label}${e.instancePath} ${e.message ?? 'invalid'}`),
+    };
+  }
+  if (hasDuplicateRows(data as Array<{ selectionIds: string[] }>)) {
+    return { valid: false, errors: [`${label}: duplicate selectionIds row`] };
+  }
+  return { valid: true, errors: [] };
+};
+
+export const validateForecastCombos = (data: unknown): CastValidationResult =>
+  runValidator(forecastCombosValidator, data, 'forecast_combos');
+
+export const validateTricastCombos = (data: unknown): CastValidationResult =>
+  runValidator(tricastCombosValidator, data, 'tricast_combos');

--- a/src/tests/common/castResultType.test.ts
+++ b/src/tests/common/castResultType.test.ts
@@ -1,0 +1,12 @@
+import { CastResultType } from '../../common/constants/castResultType';
+
+describe('CastResultType', () => {
+  it('exposes the canonical per-combo result strings', () => {
+    expect(CastResultType.NOT_APPLICABLE).toBe('not_applicable');
+    expect(CastResultType.HIT).toBe('hit');
+    expect(CastResultType.MISSED).toBe('missed');
+    expect(CastResultType.VOID).toBe('void');
+    expect(CastResultType.SINGLE).toBe('single');
+    expect(CastResultType.FORECAST).toBe('forecast');
+  });
+});

--- a/src/tests/common/castValidator.test.ts
+++ b/src/tests/common/castValidator.test.ts
@@ -1,0 +1,58 @@
+import { validateForecastCombos, validateTricastCombos } from '../../common/validator/castValidator';
+
+describe('validateForecastCombos', () => {
+  it('accepts a non-dead-heat single-entry array', () => {
+    const result = validateForecastCombos([{ selectionIds: ['a', 'b'], dividend: 13.56 }]);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('accepts the dead-heat shape from the Trello bug', () => {
+    const result = validateForecastCombos([
+      { selectionIds: ['4190425', '4216495'], dividend: 13.56 },
+      { selectionIds: ['4190425', '4210872'], dividend: 22.35 },
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an empty array', () => {
+    const result = validateForecastCombos([]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects wrong selectionIds length', () => {
+    const result = validateForecastCombos([{ selectionIds: ['a', 'b', 'c'], dividend: 13.56 }]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects non-positive dividend', () => {
+    const result = validateForecastCombos([{ selectionIds: ['a', 'b'], dividend: 0 }]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects duplicate rows', () => {
+    const result = validateForecastCombos([
+      { selectionIds: ['a', 'b'], dividend: 13.56 },
+      { selectionIds: ['a', 'b'], dividend: 22.35 },
+    ]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/duplicate/);
+  });
+
+  it('rejects empty selection ids', () => {
+    const result = validateForecastCombos([{ selectionIds: ['', 'b'], dividend: 13.56 }]);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateTricastCombos', () => {
+  it('accepts a 3-selection entry', () => {
+    const result = validateTricastCombos([{ selectionIds: ['a', 'b', 'c'], dividend: 50 }]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a 2-selection entry', () => {
+    const result = validateTricastCombos([{ selectionIds: ['a', 'b'], dividend: 50 }]);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/src/tests/common/raceSelectionStatus.test.ts
+++ b/src/tests/common/raceSelectionStatus.test.ts
@@ -1,0 +1,38 @@
+import { BetResultType } from '../../common/constants/betResultType';
+import { RaceSelectionStatus, raceSelectionMap } from '../../common/constants/raceSelectionStatus';
+
+describe('RaceSelectionStatus', () => {
+  it('exposes the canonical race-state strings', () => {
+    expect(RaceSelectionStatus.RUNNER).toBe('Runner');
+    expect(RaceSelectionStatus.NON_RUNNER).toBe('NonRunner');
+    expect(RaceSelectionStatus.PULLED_UP).toBe('PulledUp');
+    expect(RaceSelectionStatus.WINNER).toBe('Winner');
+    expect(RaceSelectionStatus.PLACED).toBe('Placed');
+    expect(RaceSelectionStatus.LOSER).toBe('Loser');
+    expect(RaceSelectionStatus.NON_AVAILABLE).toBe('NonAvailable');
+  });
+});
+
+describe('raceSelectionMap', () => {
+  it('maps WINNER → BetResultType.WINNER', () => {
+    expect(raceSelectionMap(RaceSelectionStatus.WINNER)).toBe(BetResultType.WINNER);
+  });
+
+  it('maps PLACED → BetResultType.PLACED', () => {
+    expect(raceSelectionMap(RaceSelectionStatus.PLACED)).toBe(BetResultType.PLACED);
+  });
+
+  it('maps LOSER → BetResultType.LOSER', () => {
+    expect(raceSelectionMap(RaceSelectionStatus.LOSER)).toBe(BetResultType.LOSER);
+  });
+
+  it('maps NON_RUNNER and PULLED_UP → VOID', () => {
+    expect(raceSelectionMap(RaceSelectionStatus.NON_RUNNER)).toBe(BetResultType.VOID);
+    expect(raceSelectionMap(RaceSelectionStatus.PULLED_UP)).toBe(BetResultType.VOID);
+  });
+
+  it('maps NON_AVAILABLE and unknown → OPEN', () => {
+    expect(raceSelectionMap(RaceSelectionStatus.NON_AVAILABLE)).toBe(BetResultType.OPEN);
+    expect(raceSelectionMap('something-else')).toBe(BetResultType.OPEN);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation for the forecast/tricast dead-heat fix ([Trello F5ril4TO](https://trello.com/c/F5ril4TO/4648-forecast-combination-with-dead-heat-bug)).

- `WinningCombo` interface ({selectionIds[], dividend}) — used across worker + CMS for paying multiple dividends on dead heats
- AJV validators `validateForecastCombos` / `validateTricastCombos` — length checks, positive dividend, no duplicate rows
- `RaceSelectionStatus` + `raceSelectionMap` migrated from swiftyPredictionsELBAPI/constant
- `CastResultType` migrated from swiftyPredictionsELBAPI/constant

All additions are purely additive. Consumer repos (swiftyPredictionsELBAPI, SwiftyPredictionsCMSEB, SwiftyPredictionsCMSWebsite) keep using their local types in this delivery and can adopt the shared exports in follow-ups.

## Test plan

- [x] 16 new unit tests pass (jest)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] Full repo test suite: 606 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)