### PR TITLE
Lucky Boost: include/exclude BOG toggle (1.0.133)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.132",
+  "version": "1.0.133",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.132",
+      "version": "1.0.133",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.132",
+  "version": "1.0.133",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
-  "sideEffects": ["*.css"],
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,8 +30,12 @@
     "react-dom": "^18.0.0"
   },
   "peerDependenciesMeta": {
-    "react": { "optional": true },
-    "react-dom": { "optional": true }
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/src/BetCalculator/accaBoost.ts
+++ b/src/BetCalculator/accaBoost.ts
@@ -46,8 +46,7 @@ export interface AccaRulesSnapshot {
 /** Leg shape consumed by the resolver — only `result` is read. */
 export interface BoostLeg {
   result?: string | null;
-  /** Fully resolved winning-leg odd under BOG (post-R4, post-SP selection).
-   *  Used by calculateLuckyBoost's one-winner branch when include_bog is true. */
+  /** Fully resolved winning-leg odd under BOG (post-R4, post-SP selection). */
   bog_odd?: number | null;
   [key: string]: unknown;
 }

--- a/src/BetCalculator/accaBoost.ts
+++ b/src/BetCalculator/accaBoost.ts
@@ -46,6 +46,9 @@ export interface AccaRulesSnapshot {
 /** Leg shape consumed by the resolver — only `result` is read. */
 export interface BoostLeg {
   result?: string | null;
+  /** Fully resolved winning-leg odd under BOG (post-R4, post-SP selection).
+   *  Used by calculateLuckyBoost's one-winner branch when include_bog is true. */
+  bog_odd?: number | null;
   [key: string]: unknown;
 }
 

--- a/src/BetCalculator/accaBoost.ts
+++ b/src/BetCalculator/accaBoost.ts
@@ -46,8 +46,6 @@ export interface AccaRulesSnapshot {
 /** Leg shape consumed by the resolver — only `result` is read. */
 export interface BoostLeg {
   result?: string | null;
-  /** Fully resolved winning-leg odd under BOG (post-R4, post-SP selection). */
-  bog_odd?: number | null;
   [key: string]: unknown;
 }
 

--- a/src/BetCalculator/luckyBoost.ts
+++ b/src/BetCalculator/luckyBoost.ts
@@ -202,10 +202,10 @@ export function calculateLuckyBoost(params: CalculateLuckyBoostParams): LuckyBoo
 
     const winningSingle = legs.find((leg) => String(leg?.result ?? '').toLowerCase() === 'winner') as
       | undefined
-      | { odd?: number | string; odd_decimal?: number | string; rule_4?: number | string };
+      | { odd?: number | string; odd_decimal?: number | string; rule_4?: number | string; bog_odd?: number | null };
     if (!winningSingle) return EMPTY;
 
-    const bogOdd = Number((winningSingle as { bog_odd?: number | null }).bog_odd ?? 0);
+    const bogOdd = Number(winningSingle.bog_odd ?? 0);
     let odd: number;
     if (params.include_bog && bogOdd > 0) {
       // bog_odd is already fully resolved (post-R4, post-SP selection); use as-is.

--- a/src/BetCalculator/luckyBoost.ts
+++ b/src/BetCalculator/luckyBoost.ts
@@ -111,6 +111,12 @@ export interface CalculateLuckyBoostParams {
   stake_per_line: number;
   /** Total payout for the bet (sum of all winning lines), used by the all-winners branch. */
   return_amount: number;
+  /** Placed-odds total payout (excludes BOG uplift). Falls back to
+   *  `return_amount` when omitted (un-migrated callers keep today's behaviour). */
+  return_amount_no_bog?: number;
+  /** When true, the calc reflects BOG: all-winners uses `return_amount`,
+   *  one-winner uses each leg's `bog_odd`. Default false (placed odds). */
+  include_bog?: boolean;
   /** All Lucky single legs with `result` + `sport_slug` + `odd` (+ optional `rule_4`). */
   resultedSingleBets: BoostLeg[];
   /** Allow-list of sport slugs. Pass `undefined` to skip the gate; `[]` to disable boost. */
@@ -178,7 +184,10 @@ export function calculateLuckyBoost(params: CalculateLuckyBoostParams): LuckyBoo
     const parsed = parseBoostValue(perType.all_winners);
     if (parsed.kind !== 'percent') return EMPTY;
     const totalStake = stake * totalLines;
-    const winnings = Number(params.return_amount) - totalStake;
+    const basis = params.include_bog
+      ? Number(params.return_amount)
+      : Number(params.return_amount_no_bog ?? params.return_amount);
+    const winnings = basis - totalStake;
     if (winnings <= 0) return EMPTY;
     let amount = winnings * (parsed.percent / 100);
     if (amount <= 0) return EMPTY;
@@ -196,8 +205,15 @@ export function calculateLuckyBoost(params: CalculateLuckyBoostParams): LuckyBoo
       | { odd?: number | string; odd_decimal?: number | string; rule_4?: number | string };
     if (!winningSingle) return EMPTY;
 
-    const rawOdd = Number(winningSingle.odd_decimal ?? winningSingle.odd ?? 0);
-    const odd = oddAfterRule4({ odd: rawOdd, rule4_percentage: winningSingle.rule_4 });
+    const bogOdd = Number((winningSingle as { bog_odd?: number | null }).bog_odd ?? 0);
+    let odd: number;
+    if (params.include_bog && bogOdd > 0) {
+      // bog_odd is already fully resolved (post-R4, post-SP selection); use as-is.
+      odd = bogOdd;
+    } else {
+      const rawOdd = Number(winningSingle.odd_decimal ?? winningSingle.odd ?? 0);
+      odd = oddAfterRule4({ odd: rawOdd, rule4_percentage: winningSingle.rule_4 });
+    }
     if (odd <= 0 || stake <= 0) return EMPTY;
 
     // Bonus is a multiplier on the winnings portion only (stake always returned):

--- a/src/tests/BetCalculator/luckyBoost.test.ts
+++ b/src/tests/BetCalculator/luckyBoost.test.ts
@@ -393,3 +393,118 @@ describe('calculateLuckyBoost — neither branch fires', () => {
     expect(r.amount).toBe(0);
   });
 });
+
+describe('calculateLuckyBoost — include_bog toggle', () => {
+  const allWinConfig = {
+    enabled: true,
+    config: { lucky15: { one_winner: 'none', all_winners: '10%' } },
+  };
+  const fourWinners = [
+    { result: 'winner', sport_slug: 'horseracing', odd: 2 },
+    { result: 'winner', sport_slug: 'horseracing', odd: 2 },
+    { result: 'winner', sport_slug: 'horseracing', odd: 2 },
+    { result: 'winner', sport_slug: 'horseracing', odd: 2 },
+  ];
+
+  it('all-winners: include_bog=true uses BOG return_amount', () => {
+    const r = calculateLuckyBoost({
+      config: allWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 200,
+      return_amount_no_bog: 150,
+      resultedSingleBets: fourWinners as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: true,
+    } as any);
+    expect(r.amount).toBeCloseTo(18.5, 2); // (200 - 15) * 10%
+    expect(r.type).toBe('all_winners');
+  });
+
+  it('all-winners: include_bog=false uses placed return_amount_no_bog', () => {
+    const r = calculateLuckyBoost({
+      config: allWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 200,
+      return_amount_no_bog: 150,
+      resultedSingleBets: fourWinners as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: false,
+    } as any);
+    expect(r.amount).toBeCloseTo(13.5, 2); // (150 - 15) * 10%
+  });
+
+  it('all-winners: omitting return_amount_no_bog falls back to return_amount (back-compat)', () => {
+    const r = calculateLuckyBoost({
+      config: allWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 200,
+      resultedSingleBets: fourWinners as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+    } as any);
+    expect(r.amount).toBeCloseTo(18.5, 2);
+  });
+
+  const oneWinConfig = {
+    enabled: true,
+    config: { lucky15: { one_winner: 'double', all_winners: 'none' } },
+  };
+  const oneWinnerLegs = [
+    { result: 'winner', sport_slug: 'horseracing', odd_decimal: 3, odd: 3, rule_4: 0, bog_odd: 5 },
+    { result: 'loser', sport_slug: 'horseracing', odd: 2 },
+    { result: 'loser', sport_slug: 'horseracing', odd: 2 },
+    { result: 'loser', sport_slug: 'horseracing', odd: 2 },
+  ];
+
+  it('one-winner: include_bog=true uses bog_odd as-is', () => {
+    const r = calculateLuckyBoost({
+      config: oneWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 2,
+      return_amount: 0,
+      return_amount_no_bog: 0,
+      resultedSingleBets: oneWinnerLegs as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: true,
+    } as any);
+    expect(r.amount).toBeCloseTo(8, 2); // (5 - 1) * 2
+    expect(r.type).toBe('one_winner');
+  });
+
+  it('one-winner: include_bog=false uses placed odd', () => {
+    const r = calculateLuckyBoost({
+      config: oneWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 2,
+      return_amount: 0,
+      return_amount_no_bog: 0,
+      resultedSingleBets: oneWinnerLegs as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: false,
+    } as any);
+    expect(r.amount).toBeCloseTo(4, 2); // (3 - 1) * 2
+  });
+
+  it('one-winner: include_bog=true but bog_odd missing falls back to placed odd', () => {
+    const legsNoBog = oneWinnerLegs.map((l) => { const { bog_odd, ...rest } = l; return rest; });
+    const r = calculateLuckyBoost({
+      config: oneWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 2,
+      return_amount: 0,
+      return_amount_no_bog: 0,
+      resultedSingleBets: legsNoBog as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: true,
+    } as any);
+    expect(r.amount).toBeCloseTo(4, 2);
+  });
+});

--- a/src/tests/BetCalculator/luckyBoost.test.ts
+++ b/src/tests/BetCalculator/luckyBoost.test.ts
@@ -447,7 +447,25 @@ describe('calculateLuckyBoost — include_bog toggle', () => {
       eligible_sports: ['horseracing'],
       max_award: 1000,
     } as any);
+    // include_bog omitted → falsy; return_amount_no_bog omitted → ?? falls back to return_amount (200)
     expect(r.amount).toBeCloseTo(18.5, 2);
+  });
+
+  it('all-winners: include_bog=false + return_amount_no_bog absent falls back to return_amount', () => {
+    const r = calculateLuckyBoost({
+      config: allWinConfig as any,
+      bet_type: 'lucky15',
+      stake_per_line: 1,
+      return_amount: 200,
+      // return_amount_no_bog intentionally absent
+      resultedSingleBets: fourWinners as any,
+      eligible_sports: ['horseracing'],
+      max_award: 1000,
+      include_bog: false,
+    } as any);
+    // return_amount_no_bog absent → ?? falls back to return_amount (200); basis = 200
+    expect(r.amount).toBeCloseTo(18.5, 2); // (200 - 15) * 10%
+    expect(r.type).toBe('all_winners');
   });
 
   const oneWinConfig = {


### PR DESCRIPTION
Adds an `include_bog` toggle to `calculateLuckyBoost` (both all-winners and one-winner branches).

- New optional params `return_amount_no_bog` + `include_bog` (default false), and per-leg `bog_odd` on `BoostLeg`.
- Back-compat: callers passing only `return_amount` keep today's behaviour.
- 34 unit tests (incl. include/exclude + fallback cases); tsc clean.

Release 1.0.133. Consumers (ELBAPI auto-settle, CMSEB manual-settle) will bump to ^1.0.133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)