### PR TITLE
feat(observability): BALANCE_CHANGE balance-change logger

### DIFF
--- a/src/observability/balanceChangeLog.ts
+++ b/src/observability/balanceChangeLog.ts
@@ -1,0 +1,65 @@
+/**
+ * Structured BALANCE_CHANGE logging — the single shared implementation for
+ * backoffice / casino / gaming / elbapi (spec 2026-06-10-balance-change-logging).
+ *
+ * One log line per users.balance write, emitted to stdout (-> CloudWatch).
+ * Query in CloudWatch Logs Insights via: filter tag = "BALANCE_CHANGE".
+ * `ledgerPaired:false` flags a wallet write with no users_transaction row —
+ * the failure mode behind CheckUserBalance wallet/ledger drift.
+ *
+ * emit() must NEVER throw into the caller: the audit log must not become a
+ * new way to break a real-money flow.
+ */
+export type BalanceChangeRepo = 'backoffice' | 'casino' | 'gaming' | 'elbapi';
+
+export interface BalanceChangeLogFields {
+  userId: number;
+  playerId?: string | number | null;
+  delta: number | null;
+  oldBalance: number | null;
+  newBalance: number | null;
+  source: string;
+  reason?: string | null;
+  ledgerTxId?: string | number | null;
+  betId?: string | number | null;
+  currency?: string | null;
+  error?: string;
+}
+
+export interface BalanceChangeLogger {
+  build: (fields: BalanceChangeLogFields) => Record<string, unknown>;
+  emit: (fields: BalanceChangeLogFields) => void;
+}
+
+export function buildBalanceChangeLog(repo: BalanceChangeRepo, fields: BalanceChangeLogFields): Record<string, unknown> {
+  return {
+    tag: 'BALANCE_CHANGE',
+    repo,
+    userId: fields.userId != null ? Number(fields.userId) : null,
+    playerId: fields.playerId != null ? String(fields.playerId) : null,
+    delta: fields.delta != null ? Number(fields.delta) : null,
+    oldBalance: fields.oldBalance != null ? Number(fields.oldBalance) : null,
+    newBalance: fields.newBalance != null ? Number(fields.newBalance) : null,
+    source: fields.source || 'unknown',
+    reason: fields.reason ?? null,
+    ledgerTxId: fields.ledgerTxId ?? null,
+    ledgerPaired: fields.ledgerTxId != null,
+    betId: fields.betId ?? null,
+    currency: fields.currency ?? null,
+    error: fields.error,
+    ts: new Date().toISOString(),
+  };
+}
+
+export function createBalanceChangeLogger(repo: BalanceChangeRepo): BalanceChangeLogger {
+  return {
+    build: (fields) => buildBalanceChangeLog(repo, fields),
+    emit: (fields) => {
+      try {
+        console.log(JSON.stringify(buildBalanceChangeLog(repo, fields)));
+      } catch (err) {
+        console.error('BALANCE_CHANGE log emit failed:', (err as Error)?.message);
+      }
+    },
+  };
+}

--- a/src/observability/balanceChangeLog.ts
+++ b/src/observability/balanceChangeLog.ts
@@ -37,7 +37,10 @@ function toFiniteOrNull(value: number | string | null | undefined): number | nul
   return Number.isFinite(n) ? n : null;
 }
 
-export function buildBalanceChangeLog(repo: BalanceChangeRepo, fields: BalanceChangeLogFields): Record<string, unknown> {
+export function buildBalanceChangeLog(
+  repo: BalanceChangeRepo,
+  fields: BalanceChangeLogFields,
+): Record<string, unknown> {
   return {
     tag: 'BALANCE_CHANGE',
     repo,

--- a/src/observability/balanceChangeLog.ts
+++ b/src/observability/balanceChangeLog.ts
@@ -13,11 +13,11 @@
 export type BalanceChangeRepo = 'backoffice' | 'casino' | 'gaming' | 'elbapi';
 
 export interface BalanceChangeLogFields {
-  userId: number;
+  userId: number | string;
   playerId?: string | number | null;
-  delta: number | null;
-  oldBalance: number | null;
-  newBalance: number | null;
+  delta: number | string | null;
+  oldBalance: number | string | null;
+  newBalance: number | string | null;
   source: string;
   reason?: string | null;
   ledgerTxId?: string | number | null;
@@ -31,18 +31,25 @@ export interface BalanceChangeLogger {
   emit: (fields: BalanceChangeLogFields) => void;
 }
 
+function toFiniteOrNull(value: number | string | null | undefined): number | null {
+  if (value == null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 export function buildBalanceChangeLog(repo: BalanceChangeRepo, fields: BalanceChangeLogFields): Record<string, unknown> {
   return {
     tag: 'BALANCE_CHANGE',
     repo,
-    userId: fields.userId != null ? Number(fields.userId) : null,
+    userId: toFiniteOrNull(fields.userId),
     playerId: fields.playerId != null ? String(fields.playerId) : null,
-    delta: fields.delta != null ? Number(fields.delta) : null,
-    oldBalance: fields.oldBalance != null ? Number(fields.oldBalance) : null,
-    newBalance: fields.newBalance != null ? Number(fields.newBalance) : null,
+    delta: toFiniteOrNull(fields.delta),
+    oldBalance: toFiniteOrNull(fields.oldBalance),
+    newBalance: toFiniteOrNull(fields.newBalance),
     source: fields.source || 'unknown',
     reason: fields.reason ?? null,
     ledgerTxId: fields.ledgerTxId ?? null,
+    // NOTE: a ledgerTxId of 0 counts as paired; callers use DB insertIds (>=1) or null.
     ledgerPaired: fields.ledgerTxId != null,
     betId: fields.betId ?? null,
     currency: fields.currency ?? null,
@@ -58,7 +65,22 @@ export function createBalanceChangeLogger(repo: BalanceChangeRepo): BalanceChang
       try {
         console.log(JSON.stringify(buildBalanceChangeLog(repo, fields)));
       } catch (err) {
-        console.error('BALANCE_CHANGE log emit failed:', (err as Error)?.message);
+        // Still emit a minimal structured line so the write is findable via
+        // `filter tag = "BALANCE_CHANGE"` even when full serialization fails.
+        try {
+          console.error(
+            JSON.stringify({
+              tag: 'BALANCE_CHANGE',
+              repo,
+              userId: toFiniteOrNull(fields?.userId),
+              source: fields?.source || 'unknown',
+              error: `emit_serialize_failed: ${(err as Error)?.message}`,
+              ts: new Date().toISOString(),
+            }),
+          );
+        } catch {
+          console.error('BALANCE_CHANGE log emit failed');
+        }
       }
     },
   };

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,1 +1,2 @@
 export * from './mysqlPoolMonitor';
+export * from './balanceChangeLog';

--- a/src/tests/observability/balanceChangeLog.test.ts
+++ b/src/tests/observability/balanceChangeLog.test.ts
@@ -1,0 +1,71 @@
+import { buildBalanceChangeLog, createBalanceChangeLogger } from '../../observability/balanceChangeLog';
+
+describe('balanceChangeLog', () => {
+  it('builds the full contract shape', () => {
+    const log = buildBalanceChangeLog('gaming', {
+      userId: 175,
+      playerId: 3443,
+      delta: -3,
+      oldBalance: 99.24,
+      newBalance: 96.24,
+      source: 'betPlacer.placeBets',
+      reason: 'bet_slip_place_lucky15',
+      ledgerTxId: 8911144,
+      betId: 445727,
+      currency: 'GBP',
+    });
+    expect(log).toMatchObject({
+      tag: 'BALANCE_CHANGE',
+      repo: 'gaming',
+      userId: 175,
+      playerId: '3443', // stringified
+      delta: -3,
+      oldBalance: 99.24,
+      newBalance: 96.24,
+      source: 'betPlacer.placeBets',
+      reason: 'bet_slip_place_lucky15',
+      ledgerTxId: 8911144,
+      ledgerPaired: true,
+      betId: 445727,
+      currency: 'GBP',
+    });
+    expect(log.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(log.error).toBeUndefined();
+  });
+
+  it('marks unpaired changes and nulls unknown fields', () => {
+    const log = buildBalanceChangeLog('casino', { userId: 1, delta: 5, oldBalance: null, newBalance: null, source: 'x' });
+    expect(log.ledgerPaired).toBe(false);
+    expect(log.ledgerTxId).toBeNull();
+    expect(log.playerId).toBeNull();
+    expect(log.currency).toBeNull();
+    expect(log.reason).toBeNull();
+    expect(log.betId).toBeNull();
+  });
+
+  it('defaults a missing source to "unknown" instead of throwing', () => {
+    const log = buildBalanceChangeLog('elbapi', { userId: 1, delta: 1, oldBalance: 0, newBalance: 1, source: '' });
+    expect(log.source).toBe('unknown');
+  });
+
+  it('factory binds the repo and emit logs one JSON line', () => {
+    const logger = createBalanceChangeLogger('backoffice');
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    logger.emit({ userId: 2, delta: 1.5, oldBalance: 10, newBalance: 11.5, source: 'manualAdjustment' });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ tag: 'BALANCE_CHANGE', repo: 'backoffice', userId: 2, newBalance: 11.5 });
+    spy.mockRestore();
+  });
+
+  it('emit never throws, even on unserializable input', () => {
+    const logger = createBalanceChangeLogger('gaming');
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const spyErr = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      logger.emit({ userId: 1, delta: 1, oldBalance: 0, newBalance: 1, source: 'x', betId: circular as never }),
+    ).not.toThrow();
+    spyErr.mockRestore();
+  });
+});

--- a/src/tests/observability/balanceChangeLog.test.ts
+++ b/src/tests/observability/balanceChangeLog.test.ts
@@ -48,6 +48,20 @@ describe('balanceChangeLog', () => {
     expect(log.source).toBe('unknown');
   });
 
+  it('coerces row-string numerics and nulls non-finite input', () => {
+    const log = buildBalanceChangeLog('gaming', {
+      userId: '175',
+      delta: '' as never,
+      oldBalance: 'abc' as never,
+      newBalance: '12.50',
+      source: 'x',
+    });
+    expect(log.userId).toBe(175);
+    expect(log.delta).toBeNull();
+    expect(log.oldBalance).toBeNull();
+    expect(log.newBalance).toBe(12.5);
+  });
+
   it('factory binds the repo and emit logs one JSON line', () => {
     const logger = createBalanceChangeLogger('backoffice');
     const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -66,6 +80,10 @@ describe('balanceChangeLog', () => {
     expect(() =>
       logger.emit({ userId: 1, delta: 1, oldBalance: 0, newBalance: 1, source: 'x', betId: circular as never }),
     ).not.toThrow();
+    expect(spyErr).toHaveBeenCalledTimes(1);
+    const fallback = JSON.parse(spyErr.mock.calls[0][0] as string);
+    expect(fallback).toMatchObject({ tag: 'BALANCE_CHANGE', repo: 'gaming', userId: 1 });
+    expect(fallback.error).toContain('emit_serialize_failed');
     spyErr.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- `createBalanceChangeLogger(repo)` / `buildBalanceChangeLog(repo, fields)` in src/observability — the single shared implementation of the BALANCE_CHANGE log contract used by gaming/casino/ELBAPI/backoffice to log every users.balance write (old/new balance, delta, source function, ledgerPaired).
- emit() never throws; serialization failure still emits a minimal structured fallback line (same tag, greppable in Logs Insights).
- Row-string numerics coerce safely: `''`/non-numeric → null, never 0/NaN.

Part 0 of 5 (consumers follow in SwiftyPredictionsCMSEB, SwiftyCasinoBackend, SwiftyGamingBackend, swiftyPredictionsELBAPI on stg-release/1.32).

## Test plan
- [x] npx jest src/tests/observability/balanceChangeLog.test.ts (6/6)
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)