### PR TITLE
1.0.134

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.133",
+  "version": "1.0.134",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.133",
+      "version": "1.0.134",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.133",
+  "version": "1.0.134",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to publish the BALANCE_CHANGE logger (PR #170 merged without a version bump, so auto-publish failed with E409 on existing 1.0.133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)