### PR TITLE
feat(providers): add swifty-feed provider — prefix 's' (5422)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.135",
+  "version": "1.0.141",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.135",
+      "version": "1.0.141",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.140",
+  "version": "1.0.141",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/common/constants/providerPrefixes.ts
+++ b/src/common/constants/providerPrefixes.ts
@@ -7,6 +7,7 @@ export enum Providers {
   SIS = 'sis',
   BETGENIUS = 'betgenius',
   RAS = 'ras',
+  SWIFTY_FEED = 'swifty-feed',
 }
 
 export const ProviderPrefixes = {
@@ -18,6 +19,7 @@ export const ProviderPrefixes = {
   d: Providers.PAMEDIA,
   m: Providers.MANUAL,
   h: Providers.RAS,
+  s: Providers.SWIFTY_FEED,
 } as const;
 
 // needed on js projects
@@ -30,6 +32,7 @@ export const FeedProviders = {
   BET_RADAR: 'g',
   MANUAL: 'm',
   RAS: 'h',
+  SWIFTY_FEED: 's',
 } as const;
 
 export const FeedProvidersNames = {
@@ -41,4 +44,5 @@ export const FeedProvidersNames = {
   [FeedProviders.BET_RADAR]: 'Bet Radar',
   [FeedProviders.MANUAL]: 'Manual',
   [FeedProviders.RAS]: 'Racing And Sports',
+  [FeedProviders.SWIFTY_FEED]: 'Swifty Feed',
 };

--- a/src/types/sportProviders.ts
+++ b/src/types/sportProviders.ts
@@ -11,6 +11,7 @@ import type { ObjectKeys } from './objectKeys';
  * f - ls sports (stored under ls_sports)
  * g - bet radar (stored under bet_radar)
  * h - racing and sports (stored under ras)
+ * s - swifty feed (stored under swifty_feed)
  */
 export type SportProviders = ObjectKeys<typeof ProviderPrefixes>;
 


### PR DESCRIPTION
## Summary

Registers the new in-house golf provider `swifty-feed` in the shared provider structures (ticket 5422).

## Changes

- `Providers.SWIFTY_FEED = 'swifty-feed'`
- `ProviderPrefixes.s = Providers.SWIFTY_FEED`
- `FeedProviders.SWIFTY_FEED = 's'`
- `FeedProvidersNames['s'] = 'Swifty Feed'`
- `SportProviders` / `RegularSportProviders` pick up `'s'` automatically (derived from `ProviderPrefixes`); `RacingSportProviders` unchanged
- Version `1.0.140` → `1.0.141`

Purely additive — no existing values or shapes change. Build clean; test suite 717 passed / 7 skipped (all pre-existing skips).

After release, the consuming repos replace their local `TODO(5422)` provider shims with these constants.