### PR TITLE
fix(up-and-down): each-way ATC is a single each-way any-to-come (AceOdds)

### DIFF
--- a/src/BetCalculator/upAndDown.ts
+++ b/src/BetCalculator/upAndDown.ts
@@ -19,6 +19,7 @@ export interface UpAndDownLeg {
   deadHeatFraction: number | null;
 }
 
+/** Effective decimal odds for a resolved leg: void -> 1.0; dead-heat shrinks the odds. */
 const effectiveOdds = (leg: UpAndDownLeg, baseOdds: number): number => {
   if (leg.isVoid) return 1;
   const fraction = leg.deadHeatFraction == null ? 1 : leg.deadHeatFraction;
@@ -26,46 +27,59 @@ const effectiveOdds = (leg: UpAndDownLeg, baseOdds: number): number => {
 };
 
 /**
- * Return for one direction: Part 1 = part1, any-to-come a single on Part 2 = part2.
- * `getOdds` selects winOdds or placeOdds; `getSuccess` selects won or placed.
+ * Return for ONE direction of an Up-and-Down: part-1 is a single on legA whose
+ * return rolls over (any-to-come) onto a single on legB.
+ *
+ * Win-only: part-1 is a win single; the ATC stake (capped at multiplier*unit)
+ * funds a win single on legB.
+ *
+ * Each-way (AceOdds "single each-way ATC"): part-1 is an EACH-WAY single on legA,
+ * so its return is win-return (if won) PLUS place-return (if placed). That combined
+ * return rolls over, capped at the each-way ATC stake = 2*multiplier*unit
+ * (multiplier*unit for the win part + multiplier*unit for the place part). The
+ * rolled stake is placed as an each-way single on legB (half win, half place).
+ * A leg that only PLACES (did not win) still produces a return and still rolls over.
  */
 const directionReturn = (
   part1: UpAndDownLeg,
   part2: UpAndDownLeg,
   unit: number,
   multiplier: number,
-  getOdds: (l: UpAndDownLeg) => number,
-  getSuccess: (l: UpAndDownLeg) => boolean,
+  eachWay: boolean,
 ): number => {
-  const part1Success = part1.isVoid || getSuccess(part1);
-  if (!part1Success) return 0;
+  const p1Won = part1.isVoid || part1.won;
+  const p1Placed = part1.isVoid || part1.placed || part1.won;
 
-  const part1Return = unit * effectiveOdds(part1, getOdds(part1));
-  const atcStake = Math.min(multiplier * unit, part1Return);
+  let part1Return = 0;
+  if (p1Won) part1Return += unit * effectiveOdds(part1, part1.winOdds);
+  if (eachWay && p1Placed) part1Return += unit * effectiveOdds(part1, part1.placeOdds);
+  if (part1Return <= 0) return 0;
+
+  const atcCap = (eachWay ? 2 : 1) * multiplier * unit;
+  const atcStake = Math.min(atcCap, part1Return);
   const leftover = part1Return - atcStake;
 
-  const part2Success = part2.isVoid || getSuccess(part2);
-  const atcReturn = part2Success ? atcStake * effectiveOdds(part2, getOdds(part2)) : 0;
+  const p2Won = part2.isVoid || part2.won;
+  const p2Placed = part2.isVoid || part2.placed || part2.won;
+
+  let atcReturn = 0;
+  if (eachWay) {
+    const halfStake = atcStake / 2;
+    if (p2Won) atcReturn += halfStake * effectiveOdds(part2, part2.winOdds);
+    if (p2Placed) atcReturn += halfStake * effectiveOdds(part2, part2.placeOdds);
+  } else if (p2Won) {
+    atcReturn += atcStake * effectiveOdds(part2, part2.winOdds);
+  }
+
   return leftover + atcReturn;
 };
 
-const partReturn = (
-  legA: UpAndDownLeg,
-  legB: UpAndDownLeg,
-  unit: number,
-  multiplier: number,
-  getOdds: (l: UpAndDownLeg) => number,
-  getSuccess: (l: UpAndDownLeg) => boolean,
-): number =>
-  directionReturn(legA, legB, unit, multiplier, getOdds, getSuccess) +
-  directionReturn(legB, legA, unit, multiplier, getOdds, getSuccess);
-
 /**
- * Gross (stake-inclusive) return for one Up-and-Down pair.
+ * Gross (stake-inclusive) return for one Up-and-Down pair (both directions).
  *
- * SSA: Part-2 ATC stake = min(unit, Part-1 return).
- * DSA: Part-2 ATC stake = min(2*unit, Part-1 return).
- * Each-way: win part (win odds, won) + place part (place odds, placed), each with its own ATC cap.
+ * SSA: ATC stake multiplier = 1. DSA: multiplier = 2.
+ * Each-way is a single each-way any-to-come (see directionReturn): the winning/
+ * placed leg's full each-way return funds an each-way single on the other leg.
  */
 export const calculateUpAndDownReturn = (
   style: UpAndDownStyle,
@@ -75,26 +89,8 @@ export const calculateUpAndDownReturn = (
   eachWay: boolean,
 ): number => {
   const multiplier = style === 'dsa' ? 2 : 1;
-
-  const winPart = partReturn(
-    legA,
-    legB,
-    unitStake,
-    multiplier,
-    (l) => l.winOdds,
-    (l) => l.won,
+  return (
+    directionReturn(legA, legB, unitStake, multiplier, eachWay) +
+    directionReturn(legB, legA, unitStake, multiplier, eachWay)
   );
-
-  if (!eachWay) return winPart;
-
-  const placePart = partReturn(
-    legA,
-    legB,
-    unitStake,
-    multiplier,
-    (l) => l.placeOdds,
-    (l) => l.placed || l.won,
-  );
-
-  return winPart + placePart;
 };

--- a/src/tests/BetCalculator/upAndDown.test.ts
+++ b/src/tests/BetCalculator/upAndDown.test.ts
@@ -55,11 +55,14 @@ describe('Up-and-Down SSA each-way, A(win3/place2) B(win2/place1.5), unit=10', (
   it('all win (won & placed) -> 130 (win 80 + place 50)', () => {
     expect(calculateUpAndDownReturn('ssa', A(true, true), B(true, true), S, true)).toBeCloseTo(130, 6);
   });
-  it('A win+placed, B placed-only -> 70 (win 20 + place 50)', () => {
-    expect(calculateUpAndDownReturn('ssa', A(true, true), B(false, true), S, true)).toBeCloseTo(70, 6);
+  // Each-way = ONE each-way any-to-come (AceOdds): the placed leg's full each-way
+  // return funds an each-way single on the other leg. A wins@3/places@2 -> part-1
+  // return 50; ATC each-way stake capped at 2*unit=20 (10 win + 10 place); B places@1.5.
+  it('A win+placed, B placed-only -> 82.5', () => {
+    expect(calculateUpAndDownReturn('ssa', A(true, true), B(false, true), S, true)).toBeCloseTo(82.5, 6);
   });
-  it('both placed-only -> 50 (win 0 + place 50)', () => {
-    expect(calculateUpAndDownReturn('ssa', A(false, true), B(false, true), S, true)).toBeCloseTo(50, 6);
+  it('both placed-only -> 30', () => {
+    expect(calculateUpAndDownReturn('ssa', A(false, true), B(false, true), S, true)).toBeCloseTo(30, 6);
   });
   it('both lose -> 0', () => {
     expect(calculateUpAndDownReturn('ssa', A(false, false), B(false, false), S, true)).toBeCloseTo(0, 6);
@@ -85,5 +88,18 @@ describe('Up-and-Down SSA each-way regression: won leg without explicit placed',
     const A = leg({ winOdds: 3, placeOdds: 2, won: true, placed: false });
     const B = leg({ winOdds: 2, placeOdds: 1.5, won: true, placed: false });
     expect(calculateUpAndDownReturn('ssa', A, B, S, true)).toBeCloseTo(130, 6);
+  });
+});
+
+describe('Up-and-Down each-way ATC — reported staging bets (BO 26713/26716/26717)', () => {
+  // A "Rathmeehan Judi" WON: win 2.375, place (2.375-1)/4+1 = 1.34375
+  // B "Non Stop Tommy" PLACED-only: win 1.55, place (1.55-1)/5+1 = 1.11
+  const A = leg({ winOdds: 2.375, placeOdds: 1.34375, won: true, placed: true });
+  const B = leg({ winOdds: 1.55, placeOdds: 1.11, won: false, placed: true });
+  it('BO 26716 SSA each-way, unit 1 -> 4.8927', () => {
+    expect(calculateUpAndDownReturn('ssa', A, B, 1, true)).toBeCloseTo(4.8927, 4);
+  });
+  it('BO 26717 DSA each-way, unit 1 -> 4.1278', () => {
+    expect(calculateUpAndDownReturn('dsa', A, B, 1, true)).toBeCloseTo(4.1278, 4);
   });
 });


### PR DESCRIPTION
## What & why

Each-way **Up-and-Down** bets (Single/Double Stakes About = SSA/DSA, and Round Robin, whose 3 SSA pairs reuse this function) were **systematically under-paying**.

`calculateUpAndDownReturn` computed each-way as **two fully independent any-to-come (ATC) bets** — a separate win-SSA and a separate place-SSA, each capped independently. The correct bookmaker rule (AceOdds "single each-way ATC") is that an each-way SSA/DSA is **one each-way any-to-come**: the winning/placed leg's **full each-way return** (win + place together) rolls over, capped at the each-way ATC stake (`multiplier·unit` win + `multiplier·unit` place), and funds an **each-way single** (half-win / half-place) on the other leg. A placed-but-not-won leg still produces a return and still rolls over.

AceOdds references: [SSA](https://www.aceodds.com/bet-calculator/single-stakes-about.html), [DSA](https://www.aceodds.com/bet-calculator/double-stakes-about.html), [Round Robin](https://www.aceodds.com/bet-calculator/round-robin.html).

## Reproduced staging bets (each-way, £1 unit) — before → after

| Bet | Type | Before (wrong) | After (correct) |
|---|---|---|---|
| BO 26716 | SSA | £4.28 | **£4.89** |
| BO 26717 | DSA | £3.36 | **£4.13** |
| BO 26713 | Round Robin | £13.10 | **£13.47** |

## What changes vs. what does NOT

**Changes (were under-paid):** each-way placed-but-not-won cases. E.g. EW SSA "A win / B placed" 70→82.5; "both placed" 50→30; **EW all-win DSA 170→167.5** (the old independent-chain over-paid all-win DSA too).

**Unchanged (invariants, verified):** all win-only SSA/DSA; void-leg handling; dead-heat; **EW all-win SSA = 130**; the "won-without-explicit-placed" regression = 130. Signature is unchanged — no consumer source edits needed.

## Tests

`src/tests/BetCalculator/upAndDown.test.ts` — 16/16 pass. Updated the two stale placed-not-won each-way assertions (they encoded the old rule) and added SSA/DSA regressions for the reported bets.

## ⚠️ Merge/publish order (important)

The consumer PRs (SwiftyGamingBackend + swiftyPredictionsELBAPI) assert the **fixed** figures and will fail CI against the currently-published `1.0.142`. Sequence:
1. Merge this PR into `master`.
2. Publish shared-lib **> 1.0.142**.
3. Bump the `@swiftyglobal/swifty-shared` dep + regen lockfiles in both consumers.
4. Merge the consumer PRs.

Also: this changes **live each-way payouts** — should be confirmed with the trading team before publish. Already-settled each-way SSA/DSA/RR bets were paid at the old figures and will need re-settlement/top-ups (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
