### PR TITLE
chore(release): bump to 1.0.143 (each-way up-and-down ATC fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.141",
+  "version": "1.0.143",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.141",
+      "version": "1.0.143",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.142",
+  "version": "1.0.143",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Release bump `1.0.142 → 1.0.143` for the each-way up-and-down any-to-come fix (#180, already merged to `master`).

After this merges, publish to npm:
```
git checkout master && git pull
npm publish
```
Then bump `@swiftyglobal/swifty-shared` to `^1.0.143` in the consumers and merge their PRs:
- SwiftyGamingBackend #8192
- swiftyPredictionsELBAPI #4810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
