### PR TITLE
feat(email): shared buildEmailOriginTrace util (1.0.144)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.143",
+  "version": "1.0.144",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.143",
+      "version": "1.0.144",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.143",
+  "version": "1.0.144",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/tests/utils/emailOriginTrace.test.ts
+++ b/src/tests/utils/emailOriginTrace.test.ts
@@ -1,0 +1,59 @@
+import { buildEmailOriginTrace, EMAIL_TRACE_MARKER_KEY } from '../../utils/emailOriginTrace';
+
+// Shared origin/trace marker for outbound backend emails. Lives in swifty-shared so
+// every backend sender (worker, gaming) stamps an IDENTICAL marker — one grep pattern
+// works across all of them.
+//
+// White-label constraint: these emails are branded per customer, so the marker MUST
+// NOT leak the platform vendor name. It uses a neutral key that reads as a generic
+// message id and carries only the id.
+
+describe('buildEmailOriginTrace', () => {
+  it('exposes a neutral, vendor-free marker key', () => {
+    expect(EMAIL_TRACE_MARKER_KEY).toBe('x-mid');
+  });
+
+  it('returns a v4-style uuid as trace_id', () => {
+    const { trace_id } = buildEmailOriginTrace();
+    expect(trace_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('generates a unique trace_id per call', () => {
+    expect(buildEmailOriginTrace().trace_id).not.toBe(buildEmailOriginTrace().trace_id);
+  });
+
+  it('labels the id with the neutral x-mid key', () => {
+    const { trace_id, html } = buildEmailOriginTrace();
+    expect(html).toContain(`x-mid:${trace_id}`);
+  });
+
+  it('embeds the id in an HTML comment (survives DOM-stripping forwards)', () => {
+    const { trace_id, html } = buildEmailOriginTrace();
+    expect(html).toMatch(new RegExp(`<!--[^>]*x-mid:${trace_id}[^>]*-->`));
+  });
+
+  it('embeds the id in a visually-hidden span (survives comment-stripping forwards)', () => {
+    const { trace_id, html } = buildEmailOriginTrace();
+    expect(html).toMatch(/<span[^>]*display:\s*none[^>]*>/i);
+    expect(html).toContain(`x-mid:${trace_id}`);
+  });
+
+  it('does NOT leak the vendor name (white-label safe)', () => {
+    const { html } = buildEmailOriginTrace();
+    expect(html.toLowerCase()).not.toContain('swifty');
+    expect(html.toLowerCase()).not.toContain('origin');
+  });
+
+  it('honours a caller-supplied trace_id instead of generating one', () => {
+    const fixed = '11111111-1111-4111-8111-111111111111';
+    const { trace_id, html } = buildEmailOriginTrace(fixed);
+    expect(trace_id).toBe(fixed);
+    expect(html).toContain(fixed);
+  });
+
+  it('produces html with no raw newlines (safe to append to an email body)', () => {
+    expect(buildEmailOriginTrace().html.includes('\n')).toBe(false);
+  });
+});

--- a/src/utils/emailOriginTrace.ts
+++ b/src/utils/emailOriginTrace.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'crypto';
+
+/**
+ * Neutral, vendor-free marker key. Backend emails are white-labelled per customer,
+ * so the key must reveal nothing about the platform vendor. "x-mid" reads as a
+ * generic message id (the kind any mail system embeds) and is the single string our
+ * tooling greps for to identify a backend-sent email and extract its trace id.
+ */
+export const EMAIL_TRACE_MARKER_KEY = 'x-mid';
+
+export interface EmailOriginTrace {
+  trace_id: string;
+  html: string;
+}
+
+/**
+ * Build a hidden, forward-surviving trace marker for outbound backend emails.
+ *
+ * Shared across every backend sender (worker, gaming, ...) so the marker is IDENTICAL
+ * everywhere — one grep pattern works across all of them, and it can't drift.
+ *
+ * Why: emails our backend sends must be identifiable when a customer later forwards
+ * them to support. The marker lets us (1) recognise an email as ours (external ESP
+ * emails won't carry it) and (2) map a forwarded .eml 1:1 to its user_audit_log row
+ * via the trace id.
+ *
+ * White-label constraint: the marker carries ONLY the id under a neutral key — no
+ * vendor name, no "origin", no brand. Any origin/brand context lives in the audit
+ * log (internal), never in the branded email body.
+ *
+ * Emitted twice on purpose:
+ *  - an HTML comment: survives clients that strip hidden DOM but keep comments;
+ *  - a display:none span: survives clients (e.g. Gmail forward) that strip comments
+ *    but keep the DOM.
+ * At least one reliably survives a forward, and both are invisible to the recipient.
+ *
+ * @param traceId - optional caller-supplied id (else a v4 uuid is generated)
+ */
+export function buildEmailOriginTrace(traceId?: string): EmailOriginTrace {
+  const id = traceId || randomUUID();
+  const marker = `${EMAIL_TRACE_MARKER_KEY}:${id}`;
+  const hiddenStyle =
+    'display:none;font-size:0;line-height:0;max-height:0;max-width:0;' +
+    'overflow:hidden;mso-hide:all;color:transparent';
+  const html = `<!-- ${marker} --><span style="${hiddenStyle}">${marker}</span>`;
+  return { trace_id: id, html };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,3 +26,4 @@ export * from './isValidUrl';
 export * from './isValidIp';
 export * from './oddsFormatter';
 export * from './name-dedup.utils';
+export * from './emailOriginTrace';


### PR DESCRIPTION
Adds a shared, vendor-neutral hidden trace marker for outbound backend emails, so every backend sender (worker, gaming, ...) stamps an **identical** marker — one grep pattern works everywhere and can't drift.

## API
`buildEmailOriginTrace(traceId?) => { trace_id, html }`
- `trace_id`: per-send v4 uuid (or the caller-supplied one)
- `html`: embeds `x-mid:<uuid>` twice — an HTML comment **and** a `display:none` span — so at least one survives a client forward (Gmail strips comments but keeps DOM; some clients do the reverse). Invisible to the recipient.
- Also exports `EMAIL_TRACE_MARKER_KEY = 'x-mid'`.

## White-label safe
The marker carries **only the id** under the neutral key `x-mid` — no vendor name, no "origin", no brand. (A guard test asserts the output contains neither "swifty" nor "origin".) Origin/brand context belongs in the audit log, never in the branded email body.

## Why
When a customer forwards an email to support, we need to tell whether it's ours (marker present → look up the id in `user_audit_log`) or from an external ESP (no marker). Consumers (gaming backend + worker) will import this and record the `trace_id` in the audit log so a forwarded `.eml` maps 1:1 to its send.

## Version
Patch bump 1.0.143 → **1.0.144** (additive, backward-compatible). Merge to `master` triggers auto-publish.

## Tests
`src/tests/utils/emailOriginTrace.test.ts` — 9 tests (uuid format/uniqueness, `x-mid` key, comment + hidden-span embedding, white-label guard, caller-supplied id, no stray newlines). Full shared suite green (64 suites, 732 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)