### PR TITLE
feat(events): expand SportEventStatuses + provider status derivation (#123)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.144",
+  "version": "1.0.145",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.144",
+      "version": "1.0.145",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.144",
+  "version": "1.0.145",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/common/constants/eventStatuses.ts
+++ b/src/common/constants/eventStatuses.ts
@@ -30,14 +30,20 @@ export const EventStatuses = {
     '3': SportEventStatuses.FINISHED,
     '4': SportEventStatuses.INTERRUPTED,
     '5': SportEventStatuses.CANCELLED,
-    '6': SportEventStatuses.CANCELLED,
+    '6': SportEventStatuses.WALKOVER,
     '7': SportEventStatuses.ABANDONED,
-    '8': SportEventStatuses.CANCELLED,
+    '8': SportEventStatuses.RETIRED,
   },
   BET_RADAR: {
-    '0': SportEventStatuses.PRE_MATCH,
-    '1': SportEventStatuses.IN_PLAY,
-    '3': SportEventStatuses.FINISHED,
-    '4': SportEventStatuses.CLOSED,
+    '0': SportEventStatuses.PRE_MATCH, // not_started
+    '1': SportEventStatuses.IN_PLAY, // live
+    '2': SportEventStatuses.FINISHED, // ended
+    '3': SportEventStatuses.SUSPENDED,
+    '4': SportEventStatuses.CANCELLED,
+    '5': SportEventStatuses.INTERRUPTED,
+    '6': SportEventStatuses.POSTPONED,
+    '7': SportEventStatuses.DELAYED,
+    '8': SportEventStatuses.ABANDONED,
+    '9': SportEventStatuses.RESCHEDULED,
   },
 } as const;

--- a/src/common/constants/sportEventStatuses.ts
+++ b/src/common/constants/sportEventStatuses.ts
@@ -9,4 +9,35 @@ export enum SportEventStatuses {
   INTERRUPTED = 'interrupted',
   COVERAGE_LOST = 'coverage_lost',
   CLOSED = 'closed',
+  // Added for #123 — provider states the canonical enum previously could not represent.
+  DELAYED = 'delayed',
+  RESCHEDULED = 'rescheduled',
+  WALKOVER = 'walkover',
+  RETIRED = 'retired',
+  VOID = 'void',
 }
+
+/**
+ * Canonical human-readable label for every event status — the single source of truth for
+ * the `current_phase` field returned by the provider status helpers.
+ *
+ * Typed as `Record<SportEventStatuses, string>` on purpose: adding a status to the enum
+ * without giving it a label here is a compile error.
+ */
+export const SportEventStatusLabels: Record<SportEventStatuses, string> = {
+  [SportEventStatuses.PRE_MATCH]: 'Pre Match',
+  [SportEventStatuses.IN_PLAY]: 'In Play',
+  [SportEventStatuses.FINISHED]: 'Finished',
+  [SportEventStatuses.ABANDONED]: 'Abandoned',
+  [SportEventStatuses.SUSPENDED]: 'Suspended',
+  [SportEventStatuses.CANCELLED]: 'Cancelled',
+  [SportEventStatuses.POSTPONED]: 'Postponed',
+  [SportEventStatuses.INTERRUPTED]: 'Interrupted',
+  [SportEventStatuses.COVERAGE_LOST]: 'Coverage Lost',
+  [SportEventStatuses.CLOSED]: 'Closed',
+  [SportEventStatuses.DELAYED]: 'Delayed',
+  [SportEventStatuses.RESCHEDULED]: 'Rescheduled',
+  [SportEventStatuses.WALKOVER]: 'Walkover',
+  [SportEventStatuses.RETIRED]: 'Retired',
+  [SportEventStatuses.VOID]: 'Void',
+};

--- a/src/tests/utils/events/getBetRadarEventStatus.spec.ts
+++ b/src/tests/utils/events/getBetRadarEventStatus.spec.ts
@@ -1,70 +1,26 @@
 import { getBetRadarEventStatus } from '../../../utils';
 import { SportEventStatuses } from '../../../common';
-import type { GetBetRadarEventStatusDto } from '../../../common';
 
 describe('getBetRadarEventStatus', () => {
-  it('should return Pre Match status when eventStatusId is 1', () => {
-    const payload: GetBetRadarEventStatusDto = {
-      eventStatusId: '1',
-    };
-
-    const result = getBetRadarEventStatus(payload);
-
-    expect(result).toEqual({
-      current_phase: 'In Play',
-      current_status: SportEventStatuses.IN_PLAY,
-    });
+  it.each<[string, SportEventStatuses, string]>([
+    ['0', SportEventStatuses.PRE_MATCH, 'Pre Match'],
+    ['1', SportEventStatuses.IN_PLAY, 'In Play'],
+    ['2', SportEventStatuses.FINISHED, 'Finished'],
+    ['3', SportEventStatuses.SUSPENDED, 'Suspended'],
+    ['4', SportEventStatuses.CANCELLED, 'Cancelled'],
+    ['5', SportEventStatuses.INTERRUPTED, 'Interrupted'],
+    ['6', SportEventStatuses.POSTPONED, 'Postponed'],
+    ['7', SportEventStatuses.DELAYED, 'Delayed'],
+    ['8', SportEventStatuses.ABANDONED, 'Abandoned'],
+    ['9', SportEventStatuses.RESCHEDULED, 'Rescheduled'],
+  ])('maps BetRadar status id "%s" to %s', (eventStatusId, current_status, current_phase) => {
+    expect(getBetRadarEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
   });
 
-  it('should return In Play status when eventStatusId is 2', () => {
-    const payload: GetBetRadarEventStatusDto = {
-      eventStatusId: '0',
-    };
-
-    const result = getBetRadarEventStatus(payload);
-
-    expect(result).toEqual({
-      current_phase: 'Pre Match',
+  it('falls back to pre_match for an unrecognised status id', () => {
+    expect(getBetRadarEventStatus({ eventStatusId: '999' })).toEqual({
       current_status: SportEventStatuses.PRE_MATCH,
-    });
-  });
-
-  it('should return Finished status when eventStatusId is 3', () => {
-    const payload: GetBetRadarEventStatusDto = {
-      eventStatusId: '3',
-    };
-
-    const result = getBetRadarEventStatus(payload);
-
-    expect(result).toEqual({
-      current_phase: 'Finished',
-      current_status: SportEventStatuses.FINISHED,
-    });
-  });
-
-  it('should return Closed status when eventStatusId is 4', () => {
-    const payload: GetBetRadarEventStatusDto = {
-      eventStatusId: '4',
-    };
-
-    const result = getBetRadarEventStatus(payload);
-
-    expect(result).toEqual({
-      current_phase: 'Closed',
-      current_status: SportEventStatuses.CLOSED,
-    });
-  });
-
-  it('should return Unknown status when eventStatusId is not recognized', () => {
-    const payload: GetBetRadarEventStatusDto = {
-      eventStatusId: '999',
-    };
-
-    const result = getBetRadarEventStatus(payload);
-
-    expect(result).toEqual({
       current_phase: 'Pre Match',
-      current_status: SportEventStatuses.PRE_MATCH,
     });
   });
 });

--- a/src/tests/utils/events/getEveryMatrixEventStatus.spec.ts
+++ b/src/tests/utils/events/getEveryMatrixEventStatus.spec.ts
@@ -69,3 +69,19 @@ describe('getEveryMatrixEventStatus', () => {
     });
   });
 });
+
+describe('getEveryMatrixEventStatus - canonical status mapping', () => {
+  const started = { eventStartTime: '2000-01-01T00:00:00.000Z', now: '2000-01-01T01:00:00.000Z' };
+
+  it.each<[string, SportEventStatuses, string]>([
+    ['4', SportEventStatuses.INTERRUPTED, 'Interrupted'],
+    ['5', SportEventStatuses.CANCELLED, 'Cancelled'],
+    ['6', SportEventStatuses.WALKOVER, 'Walkover'],
+    ['7', SportEventStatuses.ABANDONED, 'Abandoned'],
+    ['8', SportEventStatuses.RETIRED, 'Retired'],
+  ])('maps EveryMatrix status id "%s" to %s regardless of part id', (eventStatusId, current_status, current_phase) => {
+    const result = getEveryMatrixEventStatus({ eventStatusId, eventPartId: 9999, ...started });
+
+    expect(result).toEqual({ current_status, current_phase });
+  });
+});

--- a/src/tests/utils/events/getLsportEventStatus.spec.ts
+++ b/src/tests/utils/events/getLsportEventStatus.spec.ts
@@ -23,4 +23,13 @@ describe('getLsportEventStatus', () => {
       current_phase: 'In Play',
     });
   });
+
+  it.each(['0', '99'])('should fall back to pre_match for unknown status id %s', (eventStatusId) => {
+    const result = getLsportEventStatus({ eventStatusId });
+
+    expect(result).toEqual({
+      current_status: SportEventStatuses.PRE_MATCH,
+      current_phase: 'Pre Match',
+    });
+  });
 });

--- a/src/utils/events/getBetRadarEventStatus.ts
+++ b/src/utils/events/getBetRadarEventStatus.ts
@@ -1,43 +1,21 @@
 import type { EventPhaseStatus } from '../../types';
 import type { GetBetRadarEventStatusDto } from '../../common';
-import { EventStatuses, SportEventStatuses } from '../../common';
+import { EventStatuses, SportEventStatuses, SportEventStatusLabels } from '../../common';
 
 /**
- * @description Determines the status of a BetRadar sports event based on the provided parameters.
- * @param payload {GetBetRadarEventStatusDto} payload - The payload containing the event status ID.
- * @param payload.eventStatusId {number} eventStatusId - The ID of the event status.
- * @return {EventPhaseStatus} - The status of the BetRadar sports event, including the current status and phase.
+ * @description Maps a BetRadar numeric event status id to the canonical SportEventStatus and its label.
+ * @param payload {GetBetRadarEventStatusDto} - The payload containing the event status id.
+ * @param payload.eventStatusId {string} - The BetRadar status id (see EventStatuses.BET_RADAR).
+ * @return {EventPhaseStatus} - The canonical status slug plus the human-readable phase label.
  * @example
- * getBetRadarEventStatus({ eventStatusId: 1 }); // { current_status: 'PRE_MATCH', current_phase: 'Pre Match' }
- * getBetRadarEventStatus({ eventStatusId: 2 }); // { current_status: 'IN_PLAY', current_phase: 'In Play' }
- * getBetRadarEventStatus({ eventStatusId: 3 }); // { current_status: 'FINISHED', current_phase: 'Finished' }
- * getBetRadarEventStatus({ eventStatusId: 4 }); // { current_status: 'CLOSED', current_phase: 'Closed' }
- * getBetRadarEventStatus({ eventStatusId: 5 }); // { current_status: 'Unknown', current_phase: 'Unknown' }
+ * getBetRadarEventStatus({ eventStatusId: '1' }); // { current_status: 'in_play',   current_phase: 'In Play' }
+ * getBetRadarEventStatus({ eventStatusId: '4' }); // { current_status: 'cancelled', current_phase: 'Cancelled' }
+ * getBetRadarEventStatus({ eventStatusId: '99' }); // unknown -> { current_status: 'pre_match', current_phase: 'Pre Match' }
  */
 export const getBetRadarEventStatus = (payload: GetBetRadarEventStatusDto): EventPhaseStatus => {
   const { eventStatusId } = payload;
 
-  const currentStatus = EventStatuses.BET_RADAR[eventStatusId];
+  const current_status = EventStatuses.BET_RADAR[eventStatusId] ?? SportEventStatuses.PRE_MATCH;
 
-  let currentPhase: string;
-
-  switch (currentStatus) {
-    case SportEventStatuses.PRE_MATCH:
-      currentPhase = 'Pre Match';
-      break;
-    case SportEventStatuses.IN_PLAY:
-      currentPhase = 'In Play';
-      break;
-    case SportEventStatuses.FINISHED:
-      currentPhase = 'Finished';
-      break;
-    case SportEventStatuses.CLOSED:
-      currentPhase = 'Closed';
-      break;
-    default:
-      currentPhase = 'Pre Match'; // Default phase for unrecognized statuses
-      break;
-  }
-
-  return { current_status: currentStatus || SportEventStatuses.PRE_MATCH, current_phase: currentPhase };
+  return { current_status, current_phase: SportEventStatusLabels[current_status] };
 };

--- a/src/utils/events/getEveryMatrixEventStatus.ts
+++ b/src/utils/events/getEveryMatrixEventStatus.ts
@@ -1,37 +1,34 @@
 import type { GetEveryMatrixEventStatusDto } from '../../common';
-import { EveryMatrixPhase, SportEventStatuses } from '../../common';
+import { EventStatuses, EveryMatrixPhase, SportEventStatuses, SportEventStatusLabels } from '../../common';
 import type { EventPhaseStatus } from '../../types';
 
 /**
- * Determines the current phase and status of an event based on the provided payload.
+ * Determines the current phase and status of an EveryMatrix event.
+ *
+ * The canonical status is resolved from `EventStatuses.EVERYMATRIX`; an unrecognised status id
+ * falls back to IN_PLAY (preserving the previous "anything that is not pre-match/finished is in
+ * play" behaviour). For in-play events the granular live phase comes from
+ * `EveryMatrixPhase[eventPartId]`; every other status uses its canonical label.
  *
  * @param {GetEveryMatrixEventStatusDto} payload - The data transfer object containing event details.
- * @param {string} payload.eventStatusId - The ID representing the event's status.
- * @param {string} payload.eventPartId - The ID representing the event's part/phase.
- * @param {Date} payload.eventStartTime - The start time of the event.
- * @param {Date} payload.now - The current time.
+ * @param {string} payload.eventStatusId - The provider status id.
+ * @param {number} payload.eventPartId - The provider part/phase id (drives the live-phase label).
+ * @param {string} payload.eventStartTime - Accepted for DTO compatibility; not used (status comes from the map).
+ * @param {string} payload.now - Accepted for DTO compatibility; not used.
  * @returns {EventPhaseStatus} An object containing the current phase and status of the event.
  */
 export const getEveryMatrixEventStatus = (payload: GetEveryMatrixEventStatusDto): EventPhaseStatus => {
-  const { eventStatusId, eventPartId, eventStartTime, now } = payload;
+  const { eventStatusId, eventPartId } = payload;
 
-  let current_phase: string = eventStatusId === '1' ? 'Pre Match' : EveryMatrixPhase[eventPartId];
+  const current_status: SportEventStatuses = EventStatuses.EVERYMATRIX[eventStatusId] ?? SportEventStatuses.IN_PLAY;
 
-  let current_status: SportEventStatuses =
-    eventStatusId === '1' ? SportEventStatuses.PRE_MATCH : SportEventStatuses.IN_PLAY;
+  let current_phase: string;
 
-  if (!current_phase && current_status == 'in_play') {
-    current_phase = 'In Play';
-  }
-
-  if (!current_phase && eventStartTime < now) {
-    current_phase = 'In Play';
-    current_status = SportEventStatuses.IN_PLAY;
-  }
-
-  if (eventStatusId === '3') {
-    current_phase = 'Finished';
-    current_status = SportEventStatuses.FINISHED;
+  if (current_status === SportEventStatuses.IN_PLAY) {
+    // Granular live phase from the part id, else the generic "In Play" label.
+    current_phase = EveryMatrixPhase[eventPartId] || SportEventStatusLabels[SportEventStatuses.IN_PLAY];
+  } else {
+    current_phase = SportEventStatusLabels[current_status];
   }
 
   return {

--- a/src/utils/events/getLsportEventStatus.ts
+++ b/src/utils/events/getLsportEventStatus.ts
@@ -5,13 +5,10 @@ import type { GetLSportEventStatusDto } from '../../common';
 export const getLsportEventStatus = (payload: GetLSportEventStatusDto): EventPhaseStatus => {
   const { eventStatusId } = payload;
 
-  const currentStatus = EventStatuses.LSPORTS[eventStatusId];
+  // Unknown/unmapped status ids (e.g. 0) fall back to pre_match, matching getBetRadarEventStatus.
+  const currentStatus = EventStatuses.LSPORTS[eventStatusId] ?? SportEventStatuses.PRE_MATCH;
 
-  const currentPhase = currentStatus
-    ? currentStatus === SportEventStatuses.PRE_MATCH
-      ? 'Pre Match'
-      : 'In Play'
-    : 'Pre Match';
+  const currentPhase = currentStatus === SportEventStatuses.PRE_MATCH ? 'Pre Match' : 'In Play';
 
-  return { current_status: EventStatuses.LSPORTS[eventStatusId], current_phase: currentPhase };
+  return { current_status: currentStatus, current_phase: currentPhase };
 };


### PR DESCRIPTION
## Ticket #123 — swiftyShared (source of truth)

Expands `SportEventStatuses` (walkover/retired/delayed/rescheduled/void) and refactors betRadar/everyMatrix/lsport per-provider status derivation. This is the canonical source consumed by CMSEB / ELBAPI / Gaming.

- Version bumped **1.0.144 → 1.0.145**.
- Tests: `jest` 57/57 (8 suites); `tsc --noEmit` clean.

> Merging to `master` triggers `autoPublish.workflow.yml` → `npm publish` of **1.0.145** to GitHub Packages. Consumers then bump their lockfiles to 1.0.145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
