### PR TITLE
feat(events): derive swifty-feed event status instead of defaulting to pre-match (5422)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.145",
+  "version": "1.0.146",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftyglobal/swifty-shared",
-      "version": "1.0.145",
+      "version": "1.0.146",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.145",
+  "version": "1.0.146",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/common/constants/eventStatuses.ts
+++ b/src/common/constants/eventStatuses.ts
@@ -46,4 +46,9 @@ export const EventStatuses = {
     '8': SportEventStatuses.ABANDONED,
     '9': SportEventStatuses.RESCHEDULED,
   },
+  SWIFTY_FEED: {
+    '1': SportEventStatuses.PRE_MATCH, // scheduled
+    '2': SportEventStatuses.IN_PLAY, // in_progress
+    '3': SportEventStatuses.FINISHED, // completed
+  },
 } as const;

--- a/src/common/dto/events/getProviderEventStatus.dto.ts
+++ b/src/common/dto/events/getProviderEventStatus.dto.ts
@@ -2,9 +2,11 @@ import type { GetLSportEventStatusDto } from './getLSportEventStatus.dto';
 import type { GetEveryMatrixEventStatusDto } from './getEveryMatrixEventStatus.dto';
 import type { GetManualEventStatusDto } from './getManualEventStatus.dto';
 import type { GetBetRadarEventStatusDto } from './getBetRadarEventStatus.dto';
+import type { GetSwiftyFeedEventStatusDto } from './getSwiftyFeedEventStatus.dto';
 
 export type GetProviderEventStatusDto =
   | GetEveryMatrixEventStatusDto
   | GetLSportEventStatusDto
   | GetManualEventStatusDto
-  | GetBetRadarEventStatusDto;
+  | GetBetRadarEventStatusDto
+  | GetSwiftyFeedEventStatusDto;

--- a/src/common/dto/events/getSwiftyFeedEventStatus.dto.ts
+++ b/src/common/dto/events/getSwiftyFeedEventStatus.dto.ts
@@ -1,0 +1,8 @@
+export interface GetSwiftyFeedEventStatusDto {
+  /**
+   * The feed's `events.event_status_id` (see EventStatuses.SWIFTY_FEED).
+   * Accepts a number as well as a string: the column is a MySQL INT, so mysql2
+   * hands it back as a number, while callers reading it off a typed row may pass a string.
+   */
+  eventStatusId: string | number;
+}

--- a/src/common/dto/events/index.ts
+++ b/src/common/dto/events/index.ts
@@ -6,3 +6,4 @@ export * from './getPaMediaEventStatus.dto';
 export * from './getBetRadarEventStatus.dto';
 export * from './getProviderEventStatus.dto';
 export * from './getRasEventStatus.dto';
+export * from './getSwiftyFeedEventStatus.dto';

--- a/src/tests/utils/events/getProviderEventStatus.spec.ts
+++ b/src/tests/utils/events/getProviderEventStatus.spec.ts
@@ -2,12 +2,14 @@ import { getProviderEventStatus } from '../../../utils';
 import { getBetRadarEventStatus, getManualEventPhaseStatus } from '../../../utils';
 import { getLsportEventStatus } from '../../../utils';
 import { getEveryMatrixEventStatus } from '../../../utils';
+import { getSwiftyFeedEventStatus } from '../../../utils';
 import { getProviderWithoutId } from '../../../utils';
 import type {
   GetBetRadarEventStatusDto,
   GetEveryMatrixEventStatusDto,
   GetLSportEventStatusDto,
   GetManualEventStatusDto,
+  GetSwiftyFeedEventStatusDto,
 } from '../../../common';
 import { SportEventStatuses } from '../../../common';
 import type { EventPhaseStatus } from '../../../types';
@@ -17,6 +19,7 @@ jest.mock('../../../utils/events/getManualEventStatus');
 jest.mock('../../../utils/events/getLsportEventStatus');
 jest.mock('../../../utils/events/getEveryMatrixEventStatus');
 jest.mock('../../../utils/events/getBetRadarEventStatus');
+jest.mock('../../../utils/events/getSwiftyFeedEventStatus');
 
 describe('getProviderEventStatus', () => {
   const mockGetProviderWithoutId = getProviderWithoutId as jest.Mock;
@@ -24,6 +27,7 @@ describe('getProviderEventStatus', () => {
   const mockGetLsportEventStatus = getLsportEventStatus as jest.Mock;
   const mockGetEveryMatrixEventStatus = getEveryMatrixEventStatus as jest.Mock;
   const mockGetBetRadarEventStatus = getBetRadarEventStatus as jest.Mock;
+  const mockGetSwiftyFeedEventStatus = getSwiftyFeedEventStatus as jest.Mock;
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -93,6 +97,24 @@ describe('getProviderEventStatus', () => {
 
     expect(mockGetProviderWithoutId).toHaveBeenCalledWith('g-123');
     expect(mockGetBetRadarEventStatus).toHaveBeenCalledWith(payload);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should call getSwiftyFeedEventStatus for provider s', () => {
+    mockGetProviderWithoutId.mockReturnValue('s');
+    const payload: GetSwiftyFeedEventStatusDto = { eventStatusId: 2 };
+
+    const expectedResult: EventPhaseStatus = {
+      current_phase: 'In Play',
+      current_status: SportEventStatuses.IN_PLAY,
+    };
+
+    mockGetSwiftyFeedEventStatus.mockReturnValue(expectedResult);
+
+    const result = getProviderEventStatus('s-180', payload);
+
+    expect(mockGetProviderWithoutId).toHaveBeenCalledWith('s-180');
+    expect(mockGetSwiftyFeedEventStatus).toHaveBeenCalledWith(payload);
     expect(result).toEqual(expectedResult);
   });
 

--- a/src/tests/utils/events/getSwiftyFeedEventStatus.spec.ts
+++ b/src/tests/utils/events/getSwiftyFeedEventStatus.spec.ts
@@ -1,0 +1,54 @@
+import { getProviderEventStatus, getSwiftyFeedEventStatus } from '../../../utils';
+import { SportEventStatuses } from '../../../common';
+
+describe('getSwiftyFeedEventStatus', () => {
+  it.each<[string, SportEventStatuses, string]>([
+    ['1', SportEventStatuses.PRE_MATCH, 'Pre Match'],
+    ['2', SportEventStatuses.IN_PLAY, 'In Play'],
+    ['3', SportEventStatuses.FINISHED, 'Finished'],
+  ])('maps swifty-feed status id "%s" to %s', (eventStatusId, current_status, current_phase) => {
+    expect(getSwiftyFeedEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
+  });
+
+  // The feed stores event_status_id as a MySQL INT, so mysql2 hands it back as a number.
+  // Mapping by string alone would silently fall back to pre_match for every live event.
+  it.each<[number, SportEventStatuses, string]>([
+    [1, SportEventStatuses.PRE_MATCH, 'Pre Match'],
+    [2, SportEventStatuses.IN_PLAY, 'In Play'],
+    [3, SportEventStatuses.FINISHED, 'Finished'],
+  ])('maps numeric swifty-feed status id %s to %s', (eventStatusId, current_status, current_phase) => {
+    expect(getSwiftyFeedEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
+  });
+
+  it('falls back to pre_match for an unrecognised status id', () => {
+    expect(getSwiftyFeedEventStatus({ eventStatusId: '99' })).toEqual({
+      current_status: SportEventStatuses.PRE_MATCH,
+      current_phase: 'Pre Match',
+    });
+  });
+
+  // Regression: an 's'-prefixed id used to fall through to the dispatcher's default branch,
+  // which returned pre_match for every feed event no matter what the feed said.
+  describe('dispatched through getProviderEventStatus', () => {
+    it('resolves an in-progress feed event as in_play', () => {
+      expect(getProviderEventStatus('s-180', { eventStatusId: 2 })).toEqual({
+        current_status: SportEventStatuses.IN_PLAY,
+        current_phase: 'In Play',
+      });
+    });
+
+    it('resolves a scheduled feed event as pre_match', () => {
+      expect(getProviderEventStatus('s-180', { eventStatusId: 1 })).toEqual({
+        current_status: SportEventStatuses.PRE_MATCH,
+        current_phase: 'Pre Match',
+      });
+    });
+
+    it('resolves a completed feed event as finished', () => {
+      expect(getProviderEventStatus('s-180', { eventStatusId: 3 })).toEqual({
+        current_status: SportEventStatuses.FINISHED,
+        current_phase: 'Finished',
+      });
+    });
+  });
+});

--- a/src/utils/events/getProviderEventStatus.ts
+++ b/src/utils/events/getProviderEventStatus.ts
@@ -8,10 +8,12 @@ import type {
   GetLSportEventStatusDto,
   GetManualEventStatusDto,
   GetProviderEventStatusDto,
+  GetSwiftyFeedEventStatusDto,
 } from '../../common';
 import { SportEventStatuses } from '../../common';
 import { getProviderWithoutId } from '../getProviderWithoutId';
 import { getBetRadarEventStatus } from './getBetRadarEventStatus';
+import { getSwiftyFeedEventStatus } from './getSwiftyFeedEventStatus';
 
 export const getProviderEventStatus = (
   eventId: IdWithProvider,
@@ -28,6 +30,8 @@ export const getProviderEventStatus = (
       return getEveryMatrixEventStatus(payload as GetEveryMatrixEventStatusDto);
     case 'g':
       return getBetRadarEventStatus(payload as GetBetRadarEventStatusDto);
+    case 's':
+      return getSwiftyFeedEventStatus(payload as GetSwiftyFeedEventStatusDto);
     default:
       return { current_phase: 'Pre Match', current_status: SportEventStatuses.PRE_MATCH };
   }

--- a/src/utils/events/getSwiftyFeedEventStatus.ts
+++ b/src/utils/events/getSwiftyFeedEventStatus.ts
@@ -1,0 +1,23 @@
+import type { EventPhaseStatus } from '../../types';
+import type { GetSwiftyFeedEventStatusDto } from '../../common';
+import { EventStatuses, SportEventStatuses, SportEventStatusLabels } from '../../common';
+
+/**
+ * @description Maps a swifty-feed event status id to the canonical SportEventStatus and its label.
+ * The id is normalised to a string first: the feed column is a MySQL INT, so it arrives as a
+ * number at runtime even where a row type declares it as a string.
+ * @param payload {GetSwiftyFeedEventStatusDto} - The payload containing the event status id.
+ * @param payload.eventStatusId {string | number} - The feed status id (see EventStatuses.SWIFTY_FEED).
+ * @return {EventPhaseStatus} - The canonical status slug plus the human-readable phase label.
+ * @example
+ * getSwiftyFeedEventStatus({ eventStatusId: 2 });   // { current_status: 'in_play',  current_phase: 'In Play' }
+ * getSwiftyFeedEventStatus({ eventStatusId: '3' }); // { current_status: 'finished', current_phase: 'Finished' }
+ * getSwiftyFeedEventStatus({ eventStatusId: 99 });  // unknown -> { current_status: 'pre_match', current_phase: 'Pre Match' }
+ */
+export const getSwiftyFeedEventStatus = (payload: GetSwiftyFeedEventStatusDto): EventPhaseStatus => {
+  const { eventStatusId } = payload;
+
+  const current_status = EventStatuses.SWIFTY_FEED[String(eventStatusId)] ?? SportEventStatuses.PRE_MATCH;
+
+  return { current_status, current_phase: SportEventStatusLabels[current_status] };
+};

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -6,3 +6,4 @@ export * from './getLsportEventStatus';
 export * from './getBetRadarEventStatus';
 export * from './getProviderEventStatus';
 export * from './getRasEventStatus';
+export * from './getSwiftyFeedEventStatus';


### PR DESCRIPTION
## Problem

Swifty-feed event statuses never reach the client. Staging event `180`
("Challenge Tour - Infortar Estonian Challenge 2026") has `status = 'in_progress'` /
`event_status_id = 2` in the feed DB, but the API reports `pre_match`.

`getProviderEventStatus` switches on the one-letter provider prefix and handled only
`m`, `f`, `e`, `g`. Feed ids are prefixed `s-`, so every feed event fell through to the
`default:` branch — which returns a hardcoded `pre_match` **without reading the payload
at all**. The status id was queried, carried on the row and passed in, then discarded.

The betslip was unaffected because it never calls this dispatcher; it derives the phase
itself from `event_status_id`, which is why the same event showed correctly there.

## Impact in the gaming backend

Three call sites see `s-` rows, so this was wider than the event page:

- Event details — `current_phase`, `current_status` and `is_live` all wrong. Knock-on:
  with `event_is_live` false, an in-play golf event is gated by the **pre-match** rule
  instead of the in-play one, so it is hidden when a competition has `prematch = 0` and
  shown when `in_play = 0`.
- Sports listing — the Live filter keeps only `current_status === IN_PLAY`, so feed golf
  events could **never** appear under Live.
- Competition page — the pre-match/in-play competition and market gates are inverted.

## Change

- `EventStatuses.SWIFTY_FEED`: `1` scheduled → `pre_match`, `2` in_progress → `in_play`,
  `3` completed → `finished`.
- `getSwiftyFeedEventStatus`, following the canonical map + `SportEventStatusLabels`
  pattern established for BetRadar/EveryMatrix in #123.
- `case 's'` wired into `getProviderEventStatus`; `GetSwiftyFeedEventStatusDto` added to
  the payload union.
- Bump to `1.0.146`.

The status id is normalised with `String(...)` before lookup. The feed column is a MySQL
INT so mysql2 returns a **number**, while a consumer's row type may declare it a string
(`eventContent.model.ts` does exactly that) — matching on the string form alone would
have reintroduced the same silent fallback. Unrecognised ids keep the existing fail-safe
of `pre_match`.

This is the tail of the already-merged swifty-feed provider work (prefix `s`,
`ProviderPrefixes`, `FeedProviders`); the status dispatcher was the one place still
unaware of the provider.

## Verification

- `getSwiftyFeedEventStatus.spec.ts` — string ids, numeric ids (the real runtime shape),
  the unknown-id fail-safe, and an unmocked regression test dispatching `s-180` through
  `getProviderEventStatus` for all three statuses.
- Full suite: 65 suites / 756 passed, 7 skipped.
- `tsc --noEmit` clean; `npm run build` clean.
- Lint adds no new problems (155 problems / 99 errors before and after — all pre-existing
  on master).
- Against the built `dist`: `s-180` + `2` → `in_play`; `'2'` → `in_play`; `3` → `finished`;
  `99` → `pre_match`; `e-999` unchanged; unknown provider still defaults.

## Consumer note

No code change is needed in SwiftyGamingBackend — all three call sites already pass the
prefixed id and the status id, so they start working on the version bump alone. Worth
noting the backend currently sits on `1.0.138`, so upgrading also pulls #123, which
rewrote the EveryMatrix/BetRadar/LSport derivation — that shifts EM status behaviour
platform-wide and deserves its own deliberate test pass rather than riding along with
this fix.