### PR TITLE
feat(events): make SportEventStatusLabels the single event-phase vocabulary (#123)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftyglobal/swifty-shared",
-  "version": "1.0.146",
+  "version": "1.0.147",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",

--- a/src/common/constants/sportEventStatuses.ts
+++ b/src/common/constants/sportEventStatuses.ts
@@ -23,10 +23,17 @@ export enum SportEventStatuses {
  *
  * Typed as `Record<SportEventStatuses, string>` on purpose: adding a status to the enum
  * without giving it a label here is a compile error.
+ *
+ * These strings are not cosmetic: `current_phase` is persisted (CMS `event_settings` /
+ * `custom_events`) and matched on downstream — SwiftyGamingBackend's `formStatusFromPhases`,
+ * the CMS upcoming-event filter, and the back-office phase-override dropdown all key off them.
+ * PRE_MATCH/IN_PLAY are therefore hyphenated to match that stored vocabulary; the earlier
+ * spaced spellings ("Pre Match"/"In Play") were a second name for the same status and matched
+ * nothing downstream (#123). Do not re-space them without migrating those consumers.
  */
 export const SportEventStatusLabels: Record<SportEventStatuses, string> = {
-  [SportEventStatuses.PRE_MATCH]: 'Pre Match',
-  [SportEventStatuses.IN_PLAY]: 'In Play',
+  [SportEventStatuses.PRE_MATCH]: 'Pre-Match',
+  [SportEventStatuses.IN_PLAY]: 'In-Play',
   [SportEventStatuses.FINISHED]: 'Finished',
   [SportEventStatuses.ABANDONED]: 'Abandoned',
   [SportEventStatuses.SUSPENDED]: 'Suspended',

--- a/src/tests/utils/events/getBetRadarEventStatus.spec.ts
+++ b/src/tests/utils/events/getBetRadarEventStatus.spec.ts
@@ -3,8 +3,8 @@ import { SportEventStatuses } from '../../../common';
 
 describe('getBetRadarEventStatus', () => {
   it.each<[string, SportEventStatuses, string]>([
-    ['0', SportEventStatuses.PRE_MATCH, 'Pre Match'],
-    ['1', SportEventStatuses.IN_PLAY, 'In Play'],
+    ['0', SportEventStatuses.PRE_MATCH, 'Pre-Match'],
+    ['1', SportEventStatuses.IN_PLAY, 'In-Play'],
     ['2', SportEventStatuses.FINISHED, 'Finished'],
     ['3', SportEventStatuses.SUSPENDED, 'Suspended'],
     ['4', SportEventStatuses.CANCELLED, 'Cancelled'],
@@ -20,7 +20,7 @@ describe('getBetRadarEventStatus', () => {
   it('falls back to pre_match for an unrecognised status id', () => {
     expect(getBetRadarEventStatus({ eventStatusId: '999' })).toEqual({
       current_status: SportEventStatuses.PRE_MATCH,
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
     });
   });
 });

--- a/src/tests/utils/events/getEveryMatrixEventStatus.spec.ts
+++ b/src/tests/utils/events/getEveryMatrixEventStatus.spec.ts
@@ -14,7 +14,7 @@ describe('getEveryMatrixEventStatus', () => {
     const result = getEveryMatrixEventStatus(payload);
 
     expect(result).toEqual({
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
       current_status: SportEventStatuses.PRE_MATCH,
     });
   });
@@ -30,7 +30,7 @@ describe('getEveryMatrixEventStatus', () => {
     const result = getEveryMatrixEventStatus(payload);
 
     expect(result).toEqual({
-      current_phase: EveryMatrixPhase[5] ?? 'In Play',
+      current_phase: EveryMatrixPhase[5] ?? 'In-Play',
       current_status: SportEventStatuses.IN_PLAY,
     });
   });
@@ -64,7 +64,7 @@ describe('getEveryMatrixEventStatus', () => {
     const result = getEveryMatrixEventStatus(payload);
 
     expect(result).toEqual({
-      current_phase: 'In Play',
+      current_phase: 'In-Play',
       current_status: SportEventStatuses.IN_PLAY,
     });
   });

--- a/src/tests/utils/events/getLsportEventStatus.spec.ts
+++ b/src/tests/utils/events/getLsportEventStatus.spec.ts
@@ -9,7 +9,7 @@ describe('getLsportEventStatus', () => {
 
     expect(result).toEqual({
       current_status: SportEventStatuses.PRE_MATCH,
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
     });
   });
 
@@ -20,8 +20,18 @@ describe('getLsportEventStatus', () => {
 
     expect(result).toEqual({
       current_status: SportEventStatuses.IN_PLAY,
-      current_phase: 'In Play',
+      current_phase: 'In-Play',
     });
+  });
+
+  // Previously every non-PRE_MATCH status was labelled "In Play"; the phase now carries the
+  // status's own canonical label so an ended/cancelled L-Sports event no longer reads as live (#123).
+  it.each([
+    ['3', SportEventStatuses.FINISHED, 'Finished'],
+    ['4', SportEventStatuses.CANCELLED, 'Cancelled'],
+    ['8', SportEventStatuses.COVERAGE_LOST, 'Coverage Lost'],
+  ])('should label status id %s with its own canonical phase', (eventStatusId, current_status, current_phase) => {
+    expect(getLsportEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
   });
 
   it.each(['0', '99'])('should fall back to pre_match for unknown status id %s', (eventStatusId) => {
@@ -29,7 +39,7 @@ describe('getLsportEventStatus', () => {
 
     expect(result).toEqual({
       current_status: SportEventStatuses.PRE_MATCH,
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
     });
   });
 });

--- a/src/tests/utils/events/getProviderEventStatus.spec.ts
+++ b/src/tests/utils/events/getProviderEventStatus.spec.ts
@@ -87,7 +87,7 @@ describe('getProviderEventStatus', () => {
     };
 
     const expectedResult: EventPhaseStatus = {
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
       current_status: SportEventStatuses.PRE_MATCH,
     };
 
@@ -105,7 +105,7 @@ describe('getProviderEventStatus', () => {
     const payload: GetSwiftyFeedEventStatusDto = { eventStatusId: 2 };
 
     const expectedResult: EventPhaseStatus = {
-      current_phase: 'In Play',
+      current_phase: 'In-Play',
       current_status: SportEventStatuses.IN_PLAY,
     };
 
@@ -128,7 +128,7 @@ describe('getProviderEventStatus', () => {
 
     expect(mockGetProviderWithoutId).toHaveBeenCalledWith('x-123');
     expect(result).toEqual({
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
       current_status: SportEventStatuses.PRE_MATCH,
     });
   });

--- a/src/tests/utils/events/getSwiftyFeedEventStatus.spec.ts
+++ b/src/tests/utils/events/getSwiftyFeedEventStatus.spec.ts
@@ -3,8 +3,8 @@ import { SportEventStatuses } from '../../../common';
 
 describe('getSwiftyFeedEventStatus', () => {
   it.each<[string, SportEventStatuses, string]>([
-    ['1', SportEventStatuses.PRE_MATCH, 'Pre Match'],
-    ['2', SportEventStatuses.IN_PLAY, 'In Play'],
+    ['1', SportEventStatuses.PRE_MATCH, 'Pre-Match'],
+    ['2', SportEventStatuses.IN_PLAY, 'In-Play'],
     ['3', SportEventStatuses.FINISHED, 'Finished'],
   ])('maps swifty-feed status id "%s" to %s', (eventStatusId, current_status, current_phase) => {
     expect(getSwiftyFeedEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
@@ -13,8 +13,8 @@ describe('getSwiftyFeedEventStatus', () => {
   // The feed stores event_status_id as a MySQL INT, so mysql2 hands it back as a number.
   // Mapping by string alone would silently fall back to pre_match for every live event.
   it.each<[number, SportEventStatuses, string]>([
-    [1, SportEventStatuses.PRE_MATCH, 'Pre Match'],
-    [2, SportEventStatuses.IN_PLAY, 'In Play'],
+    [1, SportEventStatuses.PRE_MATCH, 'Pre-Match'],
+    [2, SportEventStatuses.IN_PLAY, 'In-Play'],
     [3, SportEventStatuses.FINISHED, 'Finished'],
   ])('maps numeric swifty-feed status id %s to %s', (eventStatusId, current_status, current_phase) => {
     expect(getSwiftyFeedEventStatus({ eventStatusId })).toEqual({ current_status, current_phase });
@@ -23,7 +23,7 @@ describe('getSwiftyFeedEventStatus', () => {
   it('falls back to pre_match for an unrecognised status id', () => {
     expect(getSwiftyFeedEventStatus({ eventStatusId: '99' })).toEqual({
       current_status: SportEventStatuses.PRE_MATCH,
-      current_phase: 'Pre Match',
+      current_phase: 'Pre-Match',
     });
   });
 
@@ -33,14 +33,14 @@ describe('getSwiftyFeedEventStatus', () => {
     it('resolves an in-progress feed event as in_play', () => {
       expect(getProviderEventStatus('s-180', { eventStatusId: 2 })).toEqual({
         current_status: SportEventStatuses.IN_PLAY,
-        current_phase: 'In Play',
+        current_phase: 'In-Play',
       });
     });
 
     it('resolves a scheduled feed event as pre_match', () => {
       expect(getProviderEventStatus('s-180', { eventStatusId: 1 })).toEqual({
         current_status: SportEventStatuses.PRE_MATCH,
-        current_phase: 'Pre Match',
+        current_phase: 'Pre-Match',
       });
     });
 

--- a/src/utils/events/getBetRadarEventStatus.ts
+++ b/src/utils/events/getBetRadarEventStatus.ts
@@ -8,9 +8,9 @@ import { EventStatuses, SportEventStatuses, SportEventStatusLabels } from '../..
  * @param payload.eventStatusId {string} - The BetRadar status id (see EventStatuses.BET_RADAR).
  * @return {EventPhaseStatus} - The canonical status slug plus the human-readable phase label.
  * @example
- * getBetRadarEventStatus({ eventStatusId: '1' }); // { current_status: 'in_play',   current_phase: 'In Play' }
+ * getBetRadarEventStatus({ eventStatusId: '1' }); // { current_status: 'in_play',   current_phase: 'In-Play' }
  * getBetRadarEventStatus({ eventStatusId: '4' }); // { current_status: 'cancelled', current_phase: 'Cancelled' }
- * getBetRadarEventStatus({ eventStatusId: '99' }); // unknown -> { current_status: 'pre_match', current_phase: 'Pre Match' }
+ * getBetRadarEventStatus({ eventStatusId: '99' }); // unknown -> { current_status: 'pre_match', current_phase: 'Pre-Match' }
  */
 export const getBetRadarEventStatus = (payload: GetBetRadarEventStatusDto): EventPhaseStatus => {
   const { eventStatusId } = payload;

--- a/src/utils/events/getEveryMatrixEventStatus.ts
+++ b/src/utils/events/getEveryMatrixEventStatus.ts
@@ -25,7 +25,7 @@ export const getEveryMatrixEventStatus = (payload: GetEveryMatrixEventStatusDto)
   let current_phase: string;
 
   if (current_status === SportEventStatuses.IN_PLAY) {
-    // Granular live phase from the part id, else the generic "In Play" label.
+    // Granular live phase from the part id, else the canonical "In-Play" label.
     current_phase = EveryMatrixPhase[eventPartId] || SportEventStatusLabels[SportEventStatuses.IN_PLAY];
   } else {
     current_phase = SportEventStatusLabels[current_status];

--- a/src/utils/events/getLsportEventStatus.ts
+++ b/src/utils/events/getLsportEventStatus.ts
@@ -1,5 +1,5 @@
 import type { EventPhaseStatus } from '../../types';
-import { EventStatuses, SportEventStatuses } from '../../common';
+import { EventStatuses, SportEventStatuses, SportEventStatusLabels } from '../../common';
 import type { GetLSportEventStatusDto } from '../../common';
 
 export const getLsportEventStatus = (payload: GetLSportEventStatusDto): EventPhaseStatus => {
@@ -8,7 +8,8 @@ export const getLsportEventStatus = (payload: GetLSportEventStatusDto): EventPha
   // Unknown/unmapped status ids (e.g. 0) fall back to pre_match, matching getBetRadarEventStatus.
   const currentStatus = EventStatuses.LSPORTS[eventStatusId] ?? SportEventStatuses.PRE_MATCH;
 
-  const currentPhase = currentStatus === SportEventStatuses.PRE_MATCH ? 'Pre Match' : 'In Play';
+  // Label comes from SportEventStatusLabels so there is exactly one spelling per status (#123).
+  const currentPhase = SportEventStatusLabels[currentStatus];
 
   return { current_status: currentStatus, current_phase: currentPhase };
 };

--- a/src/utils/events/getProviderEventStatus.ts
+++ b/src/utils/events/getProviderEventStatus.ts
@@ -10,7 +10,7 @@ import type {
   GetProviderEventStatusDto,
   GetSwiftyFeedEventStatusDto,
 } from '../../common';
-import { SportEventStatuses } from '../../common';
+import { SportEventStatuses, SportEventStatusLabels } from '../../common';
 import { getProviderWithoutId } from '../getProviderWithoutId';
 import { getBetRadarEventStatus } from './getBetRadarEventStatus';
 import { getSwiftyFeedEventStatus } from './getSwiftyFeedEventStatus';
@@ -33,6 +33,6 @@ export const getProviderEventStatus = (
     case 's':
       return getSwiftyFeedEventStatus(payload as GetSwiftyFeedEventStatusDto);
     default:
-      return { current_phase: 'Pre Match', current_status: SportEventStatuses.PRE_MATCH };
+      return { current_phase: SportEventStatusLabels[SportEventStatuses.PRE_MATCH], current_status: SportEventStatuses.PRE_MATCH };
   }
 };

--- a/src/utils/events/getSwiftyFeedEventStatus.ts
+++ b/src/utils/events/getSwiftyFeedEventStatus.ts
@@ -10,9 +10,9 @@ import { EventStatuses, SportEventStatuses, SportEventStatusLabels } from '../..
  * @param payload.eventStatusId {string | number} - The feed status id (see EventStatuses.SWIFTY_FEED).
  * @return {EventPhaseStatus} - The canonical status slug plus the human-readable phase label.
  * @example
- * getSwiftyFeedEventStatus({ eventStatusId: 2 });   // { current_status: 'in_play',  current_phase: 'In Play' }
+ * getSwiftyFeedEventStatus({ eventStatusId: 2 });   // { current_status: 'in_play',  current_phase: 'In-Play' }
  * getSwiftyFeedEventStatus({ eventStatusId: '3' }); // { current_status: 'finished', current_phase: 'Finished' }
- * getSwiftyFeedEventStatus({ eventStatusId: 99 });  // unknown -> { current_status: 'pre_match', current_phase: 'Pre Match' }
+ * getSwiftyFeedEventStatus({ eventStatusId: 99 });  // unknown -> { current_status: 'pre_match', current_phase: 'Pre-Match' }
  */
 export const getSwiftyFeedEventStatus = (payload: GetSwiftyFeedEventStatusDto): EventPhaseStatus => {
   const { eventStatusId } = payload;


### PR DESCRIPTION
## Why

Ticket #123 ("Sync Event Phases between gaming and cms. Move it to a shared project") set out to remove differently-named variants of the same event status. The canonical slug set (`SportEventStatuses`) did that. The **label** side did not.

`SportEventStatusLabels` spelled `PRE_MATCH`/`IN_PLAY` as `"Pre Match"`/`"In Play"`, but every downstream consumer of `current_phase` uses the hyphenated spelling:

- CMS stores `"Pre-Match"`/`"In-Play"` in `event_settings.current_phase` and `custom_events.current_phase`
- SwiftyGamingBackend's `formStatusFromPhases` keys off the hyphenated strings
- CMSEB's upcoming-event filter (`constants/eventCurrentPhase.js`) matches on them

So the shared labels matched nothing downstream — two names for the same status, which is exactly what #123 was meant to eliminate. Found while investigating a back-office phase-override regression (see the paired CMSWebsite PRs).

## What changed

- **`SportEventStatusLabels`**: `PRE_MATCH` → `"Pre-Match"`, `IN_PLAY` → `"In-Play"`. The other 13 labels were already byte-identical to the CMS vocabulary. Added a comment recording that these strings are persisted and matched on downstream, so they are not free to re-space.
- **`getLsportEventStatus`**: reads the label from `SportEventStatusLabels` instead of a hardcoded `currentStatus === PRE_MATCH ? 'Pre Match' : 'In Play'` ternary. That ternary also labelled *every* non-pre-match status as "In Play", so an ended / cancelled / coverage-lost L-Sports event reported a live phase. Each status now carries its own label.
- **`getProviderEventStatus`**: unknown-provider fallback reads the label map instead of a hardcoded string.
- Refreshed jsdoc examples and the four affected spec files.

## Blast radius

No consumer outside this package read `SportEventStatusLabels` — verified by grep across swiftyShared, SwiftyPredictionsCMSEB, SwiftyGamingBackend, SwiftyPredictionsCMSWebsite and swiftyPredictionsELBAPI. Nothing depended on the spaced spellings.

The only behaviour change beyond the two labels is the L-Sports one above, which brings it in line with what CMSEB's `eventPhase.adapter.js` already expects.

## Testing

Full jest suite: **759 passed, 7 skipped, 65 suites**. Added specs for L-Sports status ids 3 (finished), 4 (cancelled) and 8 (coverage lost) to pin the per-status labelling.

## Follow-ups (not in this PR)

- Version bumped **1.0.146 → 1.0.147**; needs publishing, then dependency bumps in CMSEB / SGB / CMSWebsite.
- After those bumps, the now-redundant duplicates can go: CMSEB's `eventPhase.adapter.js` `DETAIL_PHASE_LABEL`, `everyMatrixEventId`, and the four near-identical label→slug maps (`everyMatrixEventStatusSlug`, `sisEventStatuses`, `paEventStatusSlug`, `rasEventStatusSlug`), plus the compatibility shim in the CMSWebsite PR and SGB's inline `statusLabelMap` in `searchTrending.service.ts`.
- Two open questions that are semantics rather than naming, left alone deliberately: EveryMatrix status 5/7 (shared says cancelled/abandoned, CMSEB says suspended/interrupted — the CMS version is load-bearing for SwiftyGamingFront's `isMatchSuspended`), and CMSEB's competing 5-bucket canonicalisation in `eventCurrentPhase.js`.

Not a money path — no settlement, payout, free-bet or void logic is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)